### PR TITLE
feat: add new version of Activity Streams 2.0 context doc

### DIFF
--- a/activitystreams-history/Overview.html
+++ b/activitystreams-history/Overview.html
@@ -3,6 +3,7 @@
   PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xht
 ml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"><head><title>Document Version History</title></head><body>
+<p><a href="v1.11.jsonld">v1.11.jsonld</a> or <a href="sha256hex-a27b78b82f4980963127140d0cb74f0e8f21c0e2b8efd0368232bf9823edff5a.jsonld">sha256hex-a27b78b82f4980963127140d0cb74f0e8f21c0e2b8efd0368232bf9823edff5a.jsonld</a></p>
 <p><a href="v1.10.jsonld">v1.10.jsonld</a> or <a href="sha256hex-335026432904cf7a433516793b5ff44719c5ae752805fae721a3f0f29310bdfb.jsonld">sha256hex-335026432904cf7a433516793b5ff44719c5ae752805fae721a3f0f29310bdfb.jsonld</a></p>
 <p><a href="v1.9.jsonld">v1.9.jsonld</a> or <a href="sha256hex-2fe73afdf51e42023981f380992ba15e27484ff7c8a2cd7a890a10364f1404d1.jsonld">sha256hex-2fe73afdf51e42023981f380992ba15e27484ff7c8a2cd7a890a10364f1404d1.jsonld</a></p>
 <p><a href="v1.8.jsonld">v1.8.jsonld</a> or <a href="sha256hex-b543684a6d2e316c356b8d98a1494df5c3d0131b740f91fad7f1371c610aeae2.jsonld">sha256hex-b543684a6d2e316c356b8d98a1494df5c3d0131b740f91fad7f1371c610aeae2.jsonld</a></p>

--- a/activitystreams-history/sha256hex-a27b78b82f4980963127140d0cb74f0e8f21c0e2b8efd0368232bf9823edff5a.jsonld
+++ b/activitystreams-history/sha256hex-a27b78b82f4980963127140d0cb74f0e8f21c0e2b8efd0368232bf9823edff5a.jsonld
@@ -1,0 +1,379 @@
+{
+  "@context": {
+    "@vocab": "_:",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "as": "https://www.w3.org/ns/activitystreams#",
+    "ldp": "http://www.w3.org/ns/ldp#",
+    "vcard": "http://www.w3.org/2006/vcard/ns#",
+    "id": "@id",
+    "type": "@type",
+    "Accept": "as:Accept",
+    "Activity": "as:Activity",
+    "IntransitiveActivity": "as:IntransitiveActivity",
+    "Add": "as:Add",
+    "Announce": "as:Announce",
+    "Application": "as:Application",
+    "Arrive": "as:Arrive",
+    "Article": "as:Article",
+    "Audio": "as:Audio",
+    "Block": "as:Block",
+    "Collection": "as:Collection",
+    "CollectionPage": "as:CollectionPage",
+    "Relationship": "as:Relationship",
+    "Create": "as:Create",
+    "Delete": "as:Delete",
+    "Dislike": "as:Dislike",
+    "Document": "as:Document",
+    "Event": "as:Event",
+    "Follow": "as:Follow",
+    "Flag": "as:Flag",
+    "Group": "as:Group",
+    "Ignore": "as:Ignore",
+    "Image": "as:Image",
+    "Invite": "as:Invite",
+    "Join": "as:Join",
+    "Leave": "as:Leave",
+    "Like": "as:Like",
+    "Link": "as:Link",
+    "Mention": "as:Mention",
+    "Note": "as:Note",
+    "Object": "as:Object",
+    "Offer": "as:Offer",
+    "OrderedCollection": "as:OrderedCollection",
+    "OrderedCollectionPage": "as:OrderedCollectionPage",
+    "Organization": "as:Organization",
+    "Page": "as:Page",
+    "Person": "as:Person",
+    "Place": "as:Place",
+    "Profile": "as:Profile",
+    "Question": "as:Question",
+    "Reject": "as:Reject",
+    "Remove": "as:Remove",
+    "Service": "as:Service",
+    "TentativeAccept": "as:TentativeAccept",
+    "TentativeReject": "as:TentativeReject",
+    "Tombstone": "as:Tombstone",
+    "Undo": "as:Undo",
+    "Update": "as:Update",
+    "Video": "as:Video",
+    "View": "as:View",
+    "Listen": "as:Listen",
+    "Read": "as:Read",
+    "Move": "as:Move",
+    "Travel": "as:Travel",
+    "IsFollowing": "as:IsFollowing",
+    "IsFollowedBy": "as:IsFollowedBy",
+    "IsContact": "as:IsContact",
+    "IsMember": "as:IsMember",
+    "subject": {
+      "@id": "as:subject",
+      "@type": "@id"
+    },
+    "relationship": {
+      "@id": "as:relationship",
+      "@type": "@id"
+    },
+    "actor": {
+      "@id": "as:actor",
+      "@type": "@id"
+    },
+    "attributedTo": {
+      "@id": "as:attributedTo",
+      "@type": "@id"
+    },
+    "attachment": {
+      "@id": "as:attachment",
+      "@type": "@id"
+    },
+    "bcc": {
+      "@id": "as:bcc",
+      "@type": "@id"
+    },
+    "bto": {
+      "@id": "as:bto",
+      "@type": "@id"
+    },
+    "cc": {
+      "@id": "as:cc",
+      "@type": "@id"
+    },
+    "context": {
+      "@id": "as:context",
+      "@type": "@id"
+    },
+    "current": {
+      "@id": "as:current",
+      "@type": "@id"
+    },
+    "first": {
+      "@id": "as:first",
+      "@type": "@id"
+    },
+    "generator": {
+      "@id": "as:generator",
+      "@type": "@id"
+    },
+    "icon": {
+      "@id": "as:icon",
+      "@type": "@id"
+    },
+    "image": {
+      "@id": "as:image",
+      "@type": "@id"
+    },
+    "inReplyTo": {
+      "@id": "as:inReplyTo",
+      "@type": "@id"
+    },
+    "items": {
+      "@id": "as:items",
+      "@type": "@id"
+    },
+    "instrument": {
+      "@id": "as:instrument",
+      "@type": "@id"
+    },
+    "orderedItems": {
+      "@id": "as:items",
+      "@type": "@id",
+      "@container": "@list"
+    },
+    "last": {
+      "@id": "as:last",
+      "@type": "@id"
+    },
+    "location": {
+      "@id": "as:location",
+      "@type": "@id"
+    },
+    "next": {
+      "@id": "as:next",
+      "@type": "@id"
+    },
+    "object": {
+      "@id": "as:object",
+      "@type": "@id"
+    },
+    "oneOf": {
+      "@id": "as:oneOf",
+      "@type": "@id"
+    },
+    "anyOf": {
+      "@id": "as:anyOf",
+      "@type": "@id"
+    },
+    "closed": {
+      "@id": "as:closed",
+      "@type": "xsd:dateTime"
+    },
+    "origin": {
+      "@id": "as:origin",
+      "@type": "@id"
+    },
+    "accuracy": {
+      "@id": "as:accuracy",
+      "@type": "xsd:float"
+    },
+    "prev": {
+      "@id": "as:prev",
+      "@type": "@id"
+    },
+    "preview": {
+      "@id": "as:preview",
+      "@type": "@id"
+    },
+    "replies": {
+      "@id": "as:replies",
+      "@type": "@id"
+    },
+    "result": {
+      "@id": "as:result",
+      "@type": "@id"
+    },
+    "audience": {
+      "@id": "as:audience",
+      "@type": "@id"
+    },
+    "partOf": {
+      "@id": "as:partOf",
+      "@type": "@id"
+    },
+    "tag": {
+      "@id": "as:tag",
+      "@type": "@id"
+    },
+    "target": {
+      "@id": "as:target",
+      "@type": "@id"
+    },
+    "to": {
+      "@id": "as:to",
+      "@type": "@id"
+    },
+    "url": {
+      "@id": "as:url",
+      "@type": "@id"
+    },
+    "altitude": {
+      "@id": "as:altitude",
+      "@type": "xsd:float"
+    },
+    "content": "as:content",
+    "contentMap": {
+      "@id": "as:content",
+      "@container": "@language"
+    },
+    "name": "as:name",
+    "nameMap": {
+      "@id": "as:name",
+      "@container": "@language"
+    },
+    "duration": {
+      "@id": "as:duration",
+      "@type": "xsd:duration"
+    },
+    "endTime": {
+      "@id": "as:endTime",
+      "@type": "xsd:dateTime"
+    },
+    "height": {
+      "@id": "as:height",
+      "@type": "xsd:nonNegativeInteger"
+    },
+    "href": {
+      "@id": "as:href",
+      "@type": "@id"
+    },
+    "hreflang": "as:hreflang",
+    "latitude": {
+      "@id": "as:latitude",
+      "@type": "xsd:float"
+    },
+    "longitude": {
+      "@id": "as:longitude",
+      "@type": "xsd:float"
+    },
+    "mediaType": "as:mediaType",
+    "published": {
+      "@id": "as:published",
+      "@type": "xsd:dateTime"
+    },
+    "radius": {
+      "@id": "as:radius",
+      "@type": "xsd:float"
+    },
+    "rel": "as:rel",
+    "startIndex": {
+      "@id": "as:startIndex",
+      "@type": "xsd:nonNegativeInteger"
+    },
+    "startTime": {
+      "@id": "as:startTime",
+      "@type": "xsd:dateTime"
+    },
+    "summary": "as:summary",
+    "summaryMap": {
+      "@id": "as:summary",
+      "@container": "@language"
+    },
+    "totalItems": {
+      "@id": "as:totalItems",
+      "@type": "xsd:nonNegativeInteger"
+    },
+    "units": "as:units",
+    "updated": {
+      "@id": "as:updated",
+      "@type": "xsd:dateTime"
+    },
+    "width": {
+      "@id": "as:width",
+      "@type": "xsd:nonNegativeInteger"
+    },
+    "describes": {
+      "@id": "as:describes",
+      "@type": "@id"
+    },
+    "formerType": {
+      "@id": "as:formerType",
+      "@type": "@id"
+    },
+    "deleted": {
+      "@id": "as:deleted",
+      "@type": "xsd:dateTime"
+    },
+    "inbox": {
+      "@id": "ldp:inbox",
+      "@type": "@id"
+    },
+    "outbox": {
+      "@id": "as:outbox",
+      "@type": "@id"
+    },
+    "following": {
+      "@id": "as:following",
+      "@type": "@id"
+    },
+    "followers": {
+      "@id": "as:followers",
+      "@type": "@id"
+    },
+    "streams": {
+      "@id": "as:streams",
+      "@type": "@id"
+    },
+    "preferredUsername": "as:preferredUsername",
+    "endpoints": {
+      "@id": "as:endpoints",
+      "@type": "@id"
+    },
+    "uploadMedia": {
+      "@id": "as:uploadMedia",
+      "@type": "@id"
+    },
+    "proxyUrl": {
+      "@id": "as:proxyUrl",
+      "@type": "@id"
+    },
+    "liked": {
+      "@id": "as:liked",
+      "@type": "@id"
+    },
+    "oauthAuthorizationEndpoint": {
+      "@id": "as:oauthAuthorizationEndpoint",
+      "@type": "@id"
+    },
+    "oauthTokenEndpoint": {
+      "@id": "as:oauthTokenEndpoint",
+      "@type": "@id"
+    },
+    "provideClientKey": {
+      "@id": "as:provideClientKey",
+      "@type": "@id"
+    },
+    "signClientKey": {
+      "@id": "as:signClientKey",
+      "@type": "@id"
+    },
+    "sharedInbox": {
+      "@id": "as:sharedInbox",
+      "@type": "@id"
+    },
+    "Public": {
+      "@id": "as:Public",
+      "@type": "@id"
+    },
+    "source": "as:source",
+    "likes": {
+      "@id": "as:likes",
+      "@type": "@id"
+    },
+    "shares": {
+      "@id": "as:shares",
+      "@type": "@id"
+    },
+    "alsoKnownAs": {
+      "@id": "as:alsoKnownAs",
+      "@type": "@id"
+    }
+  }
+}

--- a/activitystreams-history/v1.11.jsonld
+++ b/activitystreams-history/v1.11.jsonld
@@ -1,0 +1,379 @@
+{
+  "@context": {
+    "@vocab": "_:",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "as": "https://www.w3.org/ns/activitystreams#",
+    "ldp": "http://www.w3.org/ns/ldp#",
+    "vcard": "http://www.w3.org/2006/vcard/ns#",
+    "id": "@id",
+    "type": "@type",
+    "Accept": "as:Accept",
+    "Activity": "as:Activity",
+    "IntransitiveActivity": "as:IntransitiveActivity",
+    "Add": "as:Add",
+    "Announce": "as:Announce",
+    "Application": "as:Application",
+    "Arrive": "as:Arrive",
+    "Article": "as:Article",
+    "Audio": "as:Audio",
+    "Block": "as:Block",
+    "Collection": "as:Collection",
+    "CollectionPage": "as:CollectionPage",
+    "Relationship": "as:Relationship",
+    "Create": "as:Create",
+    "Delete": "as:Delete",
+    "Dislike": "as:Dislike",
+    "Document": "as:Document",
+    "Event": "as:Event",
+    "Follow": "as:Follow",
+    "Flag": "as:Flag",
+    "Group": "as:Group",
+    "Ignore": "as:Ignore",
+    "Image": "as:Image",
+    "Invite": "as:Invite",
+    "Join": "as:Join",
+    "Leave": "as:Leave",
+    "Like": "as:Like",
+    "Link": "as:Link",
+    "Mention": "as:Mention",
+    "Note": "as:Note",
+    "Object": "as:Object",
+    "Offer": "as:Offer",
+    "OrderedCollection": "as:OrderedCollection",
+    "OrderedCollectionPage": "as:OrderedCollectionPage",
+    "Organization": "as:Organization",
+    "Page": "as:Page",
+    "Person": "as:Person",
+    "Place": "as:Place",
+    "Profile": "as:Profile",
+    "Question": "as:Question",
+    "Reject": "as:Reject",
+    "Remove": "as:Remove",
+    "Service": "as:Service",
+    "TentativeAccept": "as:TentativeAccept",
+    "TentativeReject": "as:TentativeReject",
+    "Tombstone": "as:Tombstone",
+    "Undo": "as:Undo",
+    "Update": "as:Update",
+    "Video": "as:Video",
+    "View": "as:View",
+    "Listen": "as:Listen",
+    "Read": "as:Read",
+    "Move": "as:Move",
+    "Travel": "as:Travel",
+    "IsFollowing": "as:IsFollowing",
+    "IsFollowedBy": "as:IsFollowedBy",
+    "IsContact": "as:IsContact",
+    "IsMember": "as:IsMember",
+    "subject": {
+      "@id": "as:subject",
+      "@type": "@id"
+    },
+    "relationship": {
+      "@id": "as:relationship",
+      "@type": "@id"
+    },
+    "actor": {
+      "@id": "as:actor",
+      "@type": "@id"
+    },
+    "attributedTo": {
+      "@id": "as:attributedTo",
+      "@type": "@id"
+    },
+    "attachment": {
+      "@id": "as:attachment",
+      "@type": "@id"
+    },
+    "bcc": {
+      "@id": "as:bcc",
+      "@type": "@id"
+    },
+    "bto": {
+      "@id": "as:bto",
+      "@type": "@id"
+    },
+    "cc": {
+      "@id": "as:cc",
+      "@type": "@id"
+    },
+    "context": {
+      "@id": "as:context",
+      "@type": "@id"
+    },
+    "current": {
+      "@id": "as:current",
+      "@type": "@id"
+    },
+    "first": {
+      "@id": "as:first",
+      "@type": "@id"
+    },
+    "generator": {
+      "@id": "as:generator",
+      "@type": "@id"
+    },
+    "icon": {
+      "@id": "as:icon",
+      "@type": "@id"
+    },
+    "image": {
+      "@id": "as:image",
+      "@type": "@id"
+    },
+    "inReplyTo": {
+      "@id": "as:inReplyTo",
+      "@type": "@id"
+    },
+    "items": {
+      "@id": "as:items",
+      "@type": "@id"
+    },
+    "instrument": {
+      "@id": "as:instrument",
+      "@type": "@id"
+    },
+    "orderedItems": {
+      "@id": "as:items",
+      "@type": "@id",
+      "@container": "@list"
+    },
+    "last": {
+      "@id": "as:last",
+      "@type": "@id"
+    },
+    "location": {
+      "@id": "as:location",
+      "@type": "@id"
+    },
+    "next": {
+      "@id": "as:next",
+      "@type": "@id"
+    },
+    "object": {
+      "@id": "as:object",
+      "@type": "@id"
+    },
+    "oneOf": {
+      "@id": "as:oneOf",
+      "@type": "@id"
+    },
+    "anyOf": {
+      "@id": "as:anyOf",
+      "@type": "@id"
+    },
+    "closed": {
+      "@id": "as:closed",
+      "@type": "xsd:dateTime"
+    },
+    "origin": {
+      "@id": "as:origin",
+      "@type": "@id"
+    },
+    "accuracy": {
+      "@id": "as:accuracy",
+      "@type": "xsd:float"
+    },
+    "prev": {
+      "@id": "as:prev",
+      "@type": "@id"
+    },
+    "preview": {
+      "@id": "as:preview",
+      "@type": "@id"
+    },
+    "replies": {
+      "@id": "as:replies",
+      "@type": "@id"
+    },
+    "result": {
+      "@id": "as:result",
+      "@type": "@id"
+    },
+    "audience": {
+      "@id": "as:audience",
+      "@type": "@id"
+    },
+    "partOf": {
+      "@id": "as:partOf",
+      "@type": "@id"
+    },
+    "tag": {
+      "@id": "as:tag",
+      "@type": "@id"
+    },
+    "target": {
+      "@id": "as:target",
+      "@type": "@id"
+    },
+    "to": {
+      "@id": "as:to",
+      "@type": "@id"
+    },
+    "url": {
+      "@id": "as:url",
+      "@type": "@id"
+    },
+    "altitude": {
+      "@id": "as:altitude",
+      "@type": "xsd:float"
+    },
+    "content": "as:content",
+    "contentMap": {
+      "@id": "as:content",
+      "@container": "@language"
+    },
+    "name": "as:name",
+    "nameMap": {
+      "@id": "as:name",
+      "@container": "@language"
+    },
+    "duration": {
+      "@id": "as:duration",
+      "@type": "xsd:duration"
+    },
+    "endTime": {
+      "@id": "as:endTime",
+      "@type": "xsd:dateTime"
+    },
+    "height": {
+      "@id": "as:height",
+      "@type": "xsd:nonNegativeInteger"
+    },
+    "href": {
+      "@id": "as:href",
+      "@type": "@id"
+    },
+    "hreflang": "as:hreflang",
+    "latitude": {
+      "@id": "as:latitude",
+      "@type": "xsd:float"
+    },
+    "longitude": {
+      "@id": "as:longitude",
+      "@type": "xsd:float"
+    },
+    "mediaType": "as:mediaType",
+    "published": {
+      "@id": "as:published",
+      "@type": "xsd:dateTime"
+    },
+    "radius": {
+      "@id": "as:radius",
+      "@type": "xsd:float"
+    },
+    "rel": "as:rel",
+    "startIndex": {
+      "@id": "as:startIndex",
+      "@type": "xsd:nonNegativeInteger"
+    },
+    "startTime": {
+      "@id": "as:startTime",
+      "@type": "xsd:dateTime"
+    },
+    "summary": "as:summary",
+    "summaryMap": {
+      "@id": "as:summary",
+      "@container": "@language"
+    },
+    "totalItems": {
+      "@id": "as:totalItems",
+      "@type": "xsd:nonNegativeInteger"
+    },
+    "units": "as:units",
+    "updated": {
+      "@id": "as:updated",
+      "@type": "xsd:dateTime"
+    },
+    "width": {
+      "@id": "as:width",
+      "@type": "xsd:nonNegativeInteger"
+    },
+    "describes": {
+      "@id": "as:describes",
+      "@type": "@id"
+    },
+    "formerType": {
+      "@id": "as:formerType",
+      "@type": "@id"
+    },
+    "deleted": {
+      "@id": "as:deleted",
+      "@type": "xsd:dateTime"
+    },
+    "inbox": {
+      "@id": "ldp:inbox",
+      "@type": "@id"
+    },
+    "outbox": {
+      "@id": "as:outbox",
+      "@type": "@id"
+    },
+    "following": {
+      "@id": "as:following",
+      "@type": "@id"
+    },
+    "followers": {
+      "@id": "as:followers",
+      "@type": "@id"
+    },
+    "streams": {
+      "@id": "as:streams",
+      "@type": "@id"
+    },
+    "preferredUsername": "as:preferredUsername",
+    "endpoints": {
+      "@id": "as:endpoints",
+      "@type": "@id"
+    },
+    "uploadMedia": {
+      "@id": "as:uploadMedia",
+      "@type": "@id"
+    },
+    "proxyUrl": {
+      "@id": "as:proxyUrl",
+      "@type": "@id"
+    },
+    "liked": {
+      "@id": "as:liked",
+      "@type": "@id"
+    },
+    "oauthAuthorizationEndpoint": {
+      "@id": "as:oauthAuthorizationEndpoint",
+      "@type": "@id"
+    },
+    "oauthTokenEndpoint": {
+      "@id": "as:oauthTokenEndpoint",
+      "@type": "@id"
+    },
+    "provideClientKey": {
+      "@id": "as:provideClientKey",
+      "@type": "@id"
+    },
+    "signClientKey": {
+      "@id": "as:signClientKey",
+      "@type": "@id"
+    },
+    "sharedInbox": {
+      "@id": "as:sharedInbox",
+      "@type": "@id"
+    },
+    "Public": {
+      "@id": "as:Public",
+      "@type": "@id"
+    },
+    "source": "as:source",
+    "likes": {
+      "@id": "as:likes",
+      "@type": "@id"
+    },
+    "shares": {
+      "@id": "as:shares",
+      "@type": "@id"
+    },
+    "alsoKnownAs": {
+      "@id": "as:alsoKnownAs",
+      "@type": "@id"
+    }
+  }
+}


### PR DESCRIPTION
Per decision in SocialCG on Friday Mar 1 2024, this is a new snapshot of the Activity Streams 2.0 context document.

https://www.w3.org/2024/03/01-social-minutes.html