### PR TITLE
[TTWG] DAPT namespace documents

### DIFF
--- a/ttml/profile/dapt/Overview.html
+++ b/ttml/profile/dapt/Overview.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Dubbing and Audio description Profiles of TTML2 :: Namespaces</title>
+  </head>
+
+  <body>
+    <h1></h1>
+
+<p>This is a placeholder for a namespace document that permits dereferencing the Dubbing and Audio description Profiles of TTML2 namespace URIs specified at https://www.w3.org/TR/dapt/ :</p>
+
+<pre>
+http://www.w3.org/ns/ttml/profile/dapt#metadata
+http://www.w3.org/ns/ttml/profile/dapt/extension/
+</pre>
+
+<p>This namespace is stable!</p>
+
+  </body>
+</html>

--- a/ttml/profile/dapt/Overview.html
+++ b/ttml/profile/dapt/Overview.html
@@ -11,7 +11,6 @@
 
 <pre>
 http://www.w3.org/ns/ttml/profile/dapt#metadata
-http://www.w3.org/ns/ttml/profile/dapt/extension/
 </pre>
 
 <p>This namespace is stable!</p>

--- a/ttml/profile/dapt/Overview.html
+++ b/ttml/profile/dapt/Overview.html
@@ -7,7 +7,7 @@
   <body>
     <h1></h1>
 
-<p>This is a placeholder for a namespace document that permits dereferencing the Dubbing and Audio description Profiles of TTML2 namespace URIs specified at https://www.w3.org/TR/dapt/ :</p>
+<p>This is a placeholder for a namespace document that permits dereferencing the Dubbing and Audio description Profiles of TTML2 namespace URIs specified at <a href="https://www.w3.org/TR/dapt/">https://www.w3.org/TR/dapt/</a> :</p>
 
 <pre>
 http://www.w3.org/ns/ttml/profile/dapt#metadata

--- a/ttml/profile/dapt/extension/Overview.html
+++ b/ttml/profile/dapt/extension/Overview.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Dubbing and Audio description Profiles of TTML2 :: Extension Namespace</title>
+  </head>
+
+  <body>
+    <h1></h1>
+
+<p>This namespace is specified at <a href="http://www.w3.org/TR/dapt/">Dubbing and Audio description Profiles of TTML2</a></p>
+
+  </body>
+</html>

--- a/ttml/profile/dapt1.0/content
+++ b/ttml/profile/dapt1.0/content
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Dubbing and Audio description Profiles of TTML2 :: Profile Designator</title>
+  </head>
+
+  <body>
+    <h1></h1>
+
+<p>http://www.w3.org/ns/ttml/profile/dapt1.0/content is the profile designator of the DAPT Content profile of TTML2 specified at https://www.w3.org/TR/dapt/</p>
+
+<p>This namespace is stable!</p>
+
+  </body>
+</html>

--- a/ttml/profile/dapt1.0/content
+++ b/ttml/profile/dapt1.0/content
@@ -7,7 +7,7 @@
   <body>
     <h1></h1>
 
-<p>http://www.w3.org/ns/ttml/profile/dapt1.0/content is the profile designator of the DAPT Content profile of TTML2 specified at https://www.w3.org/TR/dapt/</p>
+<p><a href="http://www.w3.org/ns/ttml/profile/dapt1.0/content">http://www.w3.org/ns/ttml/profile/dapt1.0/content</a> is the profile designator of the DAPT Content profile of TTML2 specified at <a href="https://www.w3.org/TR/dapt/">https://www.w3.org/TR/dapt/</a></p>
 
 <p>This namespace is stable!</p>
 

--- a/ttml/profile/dapt1.0/processor
+++ b/ttml/profile/dapt1.0/processor
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Dubbing and Audio description Profiles of TTML2 :: Profile Designator</title>
+  </head>
+
+  <body>
+    <h1></h1>
+
+<p>http://www.w3.org/ns/ttml/profile/dapt1.0/processor is the profile designator of the DAPT Processor profile of TTML2 specified at https://www.w3.org/TR/dapt/</p>
+
+<p>This namespace is stable!</p>
+
+  </body>
+</html>

--- a/ttml/profile/dapt1.0/processor
+++ b/ttml/profile/dapt1.0/processor
@@ -7,7 +7,7 @@
   <body>
     <h1></h1>
 
-<p>http://www.w3.org/ns/ttml/profile/dapt1.0/processor is the profile designator of the DAPT Processor profile of TTML2 specified at https://www.w3.org/TR/dapt/</p>
+<p><a href="http://www.w3.org/ns/ttml/profile/dapt1.0/processor">http://www.w3.org/ns/ttml/profile/dapt1.0/processor</a> is the profile designator of the DAPT Processor profile of TTML2 specified at <a href="https://www.w3.org/TR/dapt/">https://www.w3.org/TR/dapt/</a></p>
 
 <p>This namespace is stable!</p>
 


### PR DESCRIPTION
cc /@nigelmegitt 

This is a PR for namespaces for [DAPT](https://www.w3.org/TR/dapt/) (CRS will be published 2025-03-11) specification.
Discussion and development within TTWG are performed in [another place](https://github.com/himorin/w3c-ns/pull/1), and we are bringing four documents per WG intension. 