### PR TITLE
replace redirect files with Redirect rules in .htaccess

### DIFF
--- a/iana/person/.htaccess
+++ b/iana/person/.htaccess
@@ -1,0 +1,17 @@
+RewriteEngine On
+RewriteBase /ns/iana/person/
+
+# These file names were previously encoded with combining characters
+# (diaresis and acute accent)
+# but are now encoded with pre-combined characters.
+# To keep the old URLs alive, we redirect the old encoding to the new one.
+
+RewriteRule ^Adrian_Föder(.*) Adrian_Föder$1
+RewriteRule ^Erik_Ronström(.*) Erik_Ronström$1
+RewriteRule ^Heinz-Peter_Schütz(.*) Heinz-Peter_Schütz$1
+RewriteRule ^Jan_Schütze(.*) Jan_Schütze$1
+RewriteRule ^Javier_D._Fernández(.*) Javier_D._Fernández$1
+RewriteRule ^Maik_Stührenberg(.*) Maik_Stührenberg$1
+RewriteRule ^Marcus_Ligi_Büschleb(.*) Marcus_Ligi_Büschleb$1
+RewriteRule ^Szilveszter_Tóth(.*) Szilveszter_Tóth$1
+RewriteRule ^Yüksel_Aydemir(.*) Yüksel_Aydemir$1

--- a/iana/person/Adrian_Föder.ttl.redirect
+++ b/iana/person/Adrian_Föder.ttl.redirect
@@ -1,7 +1,0 @@
-Status: 301 Moved Permanently
-Location: Adrian_F%C3%B6der.ttl
-Content-Type: text/html
-
-<!DOCTYPE html>
-<title>Redirection</title>
-<p>The correct URI for this resource is <a href="Adrian_F%C3%B6der.ttl">Adrian_F%C3%B6der.ttl</a>.

--- a/iana/person/Erik_Ronström.ttl.redirect
+++ b/iana/person/Erik_Ronström.ttl.redirect
@@ -1,7 +1,0 @@
-Status: 301 Moved Permanently
-Location: Erik_Ronstr%c3%b6m.ttl
-Content-Type: text/html
-
-<!DOCTYPE html>
-<title>Redirection</title>
-<p>The correct URI for this resource is <a href="Erik_Ronstr%c3%b6m.ttl">Erik_Ronstr%c3%b6m.ttl</a>.

--- a/iana/person/Heinz-Peter_Schütz.ttl.redirect
+++ b/iana/person/Heinz-Peter_Schütz.ttl.redirect
@@ -1,7 +1,0 @@
-Status: 301 Moved Permanently
-Location: Heinz-Peter_Sch%c3%bctz.ttl
-Content-Type: text/html
-
-<!DOCTYPE html>
-<title>Redirection</title>
-<p>The correct URI for this resource is <a href="Heinz-Peter_Sch%c3%bctz.ttl">Heinz-Peter_Sch%c3%bctz.ttl</a>.

--- a/iana/person/Jan_Schütze.ttl.redirect
+++ b/iana/person/Jan_Schütze.ttl.redirect
@@ -1,7 +1,0 @@
-Status: 301 Moved Permanently
-Location: Jan_Sch%c3%bctze.ttl
-Content-Type: text/html
-
-<!DOCTYPE html>
-<title>Redirection</title>
-<p>The correct URI for this resource is <a href="Jan_Sch%c3%bctze.ttl">Jan_Sch%c3%bctze.ttl</a>.

--- a/iana/person/Javier_D._Fernández.ttl.redirect
+++ b/iana/person/Javier_D._Fernández.ttl.redirect
@@ -1,7 +1,0 @@
-Status: 301 Moved Permanently
-Location: Javier_D._Fern%c3%a1ndez.ttl
-Content-Type: text/html
-
-<!DOCTYPE html>
-<title>Redirection</title>
-<p>The correct URI for this resource is <a href="Javier_D._Fern%c3%a1ndez.ttl">Javier_D._Fern%c3%a1ndez.ttl</a>.

--- a/iana/person/Maik_Stührenberg.ttl.redirect
+++ b/iana/person/Maik_Stührenberg.ttl.redirect
@@ -1,7 +1,0 @@
-Status: 301 Moved Permanently
-Location: Maik_St%c3%bchrenberg.ttl
-Content-Type: text/html
-
-<!DOCTYPE html>
-<title>Redirection</title>
-<p>The correct URI for this resource is <a href="Maik_St%c3%bchrenberg.ttl">Maik_St%c3%bchrenberg.ttl</a>.

--- a/iana/person/Marcus_Ligi_Büschleb.ttl.redirect
+++ b/iana/person/Marcus_Ligi_Büschleb.ttl.redirect
@@ -1,7 +1,0 @@
-Status: 301 Moved Permanently
-Location: Marcus_Ligi_B%c3%bcschleb.ttl
-Content-Type: text/html
-
-<!DOCTYPE html>
-<title>Redirection</title>
-<p>The correct URI for this resource is <a href="Marcus_Ligi_B%c3%bcschleb.ttl">Marcus_Ligi_B%c3%bcschleb.ttl</a>.

--- a/iana/person/Szilveszter_Tóth.ttl.redirect
+++ b/iana/person/Szilveszter_Tóth.ttl.redirect
@@ -1,7 +1,0 @@
-Status: 301 Moved Permanently
-Location: Szilveszter_T%c3%b3th.ttl
-Content-Type: text/html
-
-<!DOCTYPE html>
-<title>Redirection</title>
-<p>The correct URI for this resource is <a href="Szilveszter_T%c3%b3th.ttl">Szilveszter_T%c3%b3th.ttl</a>.

--- a/iana/person/Yüksel_Aydemir.ttl.redirect
+++ b/iana/person/Yüksel_Aydemir.ttl.redirect
@@ -1,7 +1,0 @@
-Status: 301 Moved Permanently
-Location: Y%c3%bcksel_Aydemir.ttl
-Content-Type: text/html
-
-<!DOCTYPE html>
-<title>Redirection</title>
-<p>The correct URI for this resource is <a href="Y%c3%bcksel_Aydemir.ttl">Y%c3%bcksel_Aydemir.ttl</a>.


### PR DESCRIPTION
This should solve MacOS's issues with filenames using combining characters