### PR TITLE
Adding epub annotation references

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -99,9 +99,9 @@ RewriteRule ^adms(\..[a-z]+)?$ legacy_adms$1 [L,R=307]
 
 
 # Adding EPUB Annotation vocabulary redirections toward documents in /TR
-# Ivan Herman, January 2026
-RewriteRule ^ea.jsonld$ https://www.w3.org/TR/epub-ann-vocabulary/index.jsonld [P]
-RewriteRule ^ea.json$ https://www.w3.org/TR/epub-ann-vocabulary/index.jsonld [P]
-RewriteRule ^ea.ttl$ https://www.w3.org/TR/epub-ann-vocabulary/index.ttl [P]
-RewriteRule ^ea.html$ https://www.w3.org/TR/epub-ann-vocabulary/index.html [P]
-RewriteRule ^epub-anno.jsonld$ https://www.w3.org/TR/epub-ann-vocabulary/index.context.jsonld [P]
+# Ivan Herman, February 2026
+RewriteRule ^ea.jsonld$ https://www.w3.org/TR/epub-anno-vocab/index.jsonld [P]
+RewriteRule ^ea.json$ https://www.w3.org/TR/epub-anno-vocab/index.jsonld [P]
+RewriteRule ^ea.ttl$ https://www.w3.org/TR/epub-anno-vocab/index.ttl [P]
+RewriteRule ^ea.html$ https://www.w3.org/TR/epub-anno-vocab/Overview.html [P]
+RewriteRule ^epub-anno.jsonld$ https://www.w3.org/TR/epub-anno-vocab/index.context.jsonld [P]

--- a/.htaccess
+++ b/.htaccess
@@ -75,7 +75,7 @@ RewriteRule ^pub-context.json$ https://w3c.github.io/pub-vocab/pub-context.jsonl
 RewriteRule ^pub-context-jsonld10.jsonld$ https://w3c.github.io/pub-vocab/pub-context-jsonld10.jsonld [P]
 RewriteRule ^pub-context-jsonld10.json$ https://w3c.github.io/pub-vocab/pub-context-jsonld10.jsonld [P]
 
-### 
+###
 # did
 RewriteRule ^did$    did-vocab/did [PT]
 RewriteRule ^did\.(.*)  did-vocab/did.$1 [PT,L]
@@ -96,3 +96,12 @@ RewriteRule ^person(\..[a-z]+)?$ legacy_person$1 [L,R=307]
 RewriteRule ^legal(\..[a-z]+)?$ legal-entity$1 [L,R=307]
 RewriteRule ^locn(\..[a-z]+)?$ legacy_locn$1 [L,R=307]
 RewriteRule ^adms(\..[a-z]+)?$ legacy_adms$1 [L,R=307]
+
+
+# Adding EPUB Annotation vocabulary redirections toward documents in /TR
+# Ivan Herman, January 2026
+RewriteRule ^ea.jsonld$ https://www.w3.org/TR/epub-ann-vocabulary/index.jsonld [P]
+RewriteRule ^ea.json$ https://www.w3.org/TR/epub-ann-vocabulary/index.jsonld [P]
+RewriteRule ^ea.ttl$ https://www.w3.org/TR/epub-ann-vocabulary/index.ttl [P]
+RewriteRule ^ea.html$ https://www.w3.org/TR/epub-ann-vocabulary/index.html [P]
+RewriteRule ^epub-anno.jsonld$ https://www.w3.org/TR/epub-ann-vocabulary/index.context.jsonld [P]

--- a/.htaccess
+++ b/.htaccess
@@ -100,8 +100,8 @@ RewriteRule ^adms(\..[a-z]+)?$ legacy_adms$1 [L,R=307]
 
 # Adding EPUB Annotation vocabulary redirections toward documents in /TR
 # Ivan Herman, February 2026
-RewriteRule ^ea.jsonld$ https://www.w3.org/TR/epub-anno-vocab/index.jsonld [P]
-RewriteRule ^ea.json$ https://www.w3.org/TR/epub-anno-vocab/index.jsonld [P]
-RewriteRule ^ea.ttl$ https://www.w3.org/TR/epub-anno-vocab/index.ttl [P]
-RewriteRule ^ea.html$ https://www.w3.org/TR/epub-anno-vocab/Overview.html [P]
-RewriteRule ^epub-anno.jsonld$ https://www.w3.org/TR/epub-anno-vocab/index.context.jsonld [P]
+RewriteRule ^ea.jsonld$ https://www.w3.org/TR/epub-anno-vocab-10/index.jsonld [P]
+RewriteRule ^ea.json$ https://www.w3.org/TR/epub-anno-vocab-10/index.jsonld [P]
+RewriteRule ^ea.ttl$ https://www.w3.org/TR/epub-anno-vocab-10/index.ttl [P]
+RewriteRule ^ea.html$ https://www.w3.org/TR/epub-anno-vocab-10/Overview.html [P]
+RewriteRule ^epub-anno.jsonld$ https://www.w3.org/TR/epub-anno-vocab-10/index.context.jsonld [P]

--- a/.htaccess
+++ b/.htaccess
@@ -100,8 +100,8 @@ RewriteRule ^adms(\..[a-z]+)?$ legacy_adms$1 [L,R=307]
 
 # Adding EPUB Annotation vocabulary redirections toward documents in /TR
 # Ivan Herman, February 2026
-RewriteRule ^ea.jsonld$ https://www.w3.org/TR/epub-anno-vocab-10/index.jsonld [P]
-RewriteRule ^ea.json$ https://www.w3.org/TR/epub-anno-vocab-10/index.jsonld [P]
-RewriteRule ^ea.ttl$ https://www.w3.org/TR/epub-anno-vocab-10/index.ttl [P]
-RewriteRule ^ea.html$ https://www.w3.org/TR/epub-anno-vocab-10/Overview.html [P]
-RewriteRule ^epub-anno.jsonld$ https://www.w3.org/TR/epub-anno-vocab-10/index.context.jsonld [P]
+RewriteRule ^ea.jsonld$ /TR/epub-anno-vocab-10/index.jsonld [L]
+RewriteRule ^ea.json$ /TR/epub-anno-vocab-10/index.jsonld [L]
+RewriteRule ^ea.ttl$ /TR/epub-anno-vocab-10/index.ttl [L]
+RewriteRule ^ea.html$ /TR/epub-anno-vocab-10/Overview.html [L]
+RewriteRule ^epub-anno.jsonld$ /TR/epub-anno-vocab-10/index.context.jsonld [L]

--- a/ea.var
+++ b/ea.var
@@ -1,0 +1,13 @@
+URI: ea
+
+URI: ea.html
+Content-Type: text/html
+
+URI: ea.ttl
+Content-Type: text/turtle; qs=0.6
+
+URI: ea.jsonld
+Content-Type: application/ld+json; qs=0.5
+
+URI: ea.json
+Content-Type: application/json; qs=0.4


### PR DESCRIPTION
- ea.var sets up a conneg for /ns/ea (vocabulary for EPUB Annotations)
- .htaccess includes redirections for /ns/ea and the ea context file to the relevant files in /TR