### PR TITLE
Namespaces going through transition requests are pre-approved

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,5 +5,4 @@ This is the repository for https://www.w3.org/ns/
 
 See also [URIs for W3C Namespaces](https://www.w3.org/guide/editor/namespaces.html).
 
-DO NOT MERGE new namespaces in this repository without proper approval from @transitions .
-
+DO NOT MERGE new namespaces in this repository without proper approval from [@w3c/transitions](https://github.com/orgs/w3c/teams/transitions). Namespaces published in W3C Technical Reports are considered approved following the approval of a related [transition request](https://github.com/w3c/transitions/issues).


### PR DESCRIPTION
This is intended at avoiding having to ask the transition team twice to approve a namespace.
