### PR TITLE
Update SPARQL service description to align with latest Editor's draft.

### DIFF
--- a/sparql-service-description.rdf
+++ b/sparql-service-description.rdf
@@ -7,219 +7,222 @@
   xmlns:xml="http://www.w3.org/XML/1998/namespace"
   xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
 >
-  <sd:Feature rdf:about="http://www.w3.org/ns/sparql-service-description#UnionDefaultGraph">
-    <rdfs:label>Union Default Graph</rdfs:label>
-    <rdfs:comment>sd:UnionDefaultGraph, when used as the object of the sd:feature property, indicates that the default graph of the dataset used during query and update evaluation (when an explicit dataset is not specified) is comprised of the union of all the named graphs in that dataset.</rdfs:comment>
-  </sd:Feature>
-  <rdf:Property rdf:about="http://www.w3.org/ns/sparql-service-description#name">
-    <rdfs:domain>
-      <rdfs:Class rdf:about="http://www.w3.org/ns/sparql-service-description#NamedGraph">
-        <rdfs:label>Named Graph</rdfs:label>
-        <rdfs:comment>An instance of sd:NamedGraph represents a named graph having a name (via sd:name) and an optional graph description (via sd:graph).</rdfs:comment>
-      </rdfs:Class>
-    </rdfs:domain>
-    <rdfs:label>name</rdfs:label>
-    <rdfs:comment>Relates a named graph to the name by which it may be referenced in a FROM/FROM NAMED clause. The object of the sd:name property is an IRI.</rdfs:comment>
-  </rdf:Property>
-  <sd:Feature rdf:about="http://www.w3.org/ns/sparql-service-description#EmptyGraphs">
-    <rdfs:label>Empty Graphs</rdfs:label>
-    <rdfs:comment>sd:EmptyGraphs, when used as the object of the sd:feature property, indicates that the underlying graph store supports empty graphs. A graph store that supports empty graphs MUST NOT remove graphs that are left empty after triples are removed from them.</rdfs:comment>
-  </sd:Feature>
-  <rdf:Property rdf:about="http://www.w3.org/ns/sparql-service-description#defaultGraph">
-    <rdfs:domain>
-      <rdfs:Class rdf:about="http://www.w3.org/ns/sparql-service-description#Dataset">
-        <rdfs:subClassOf>
-          <rdfs:Class rdf:about="http://www.w3.org/ns/sparql-service-description#GraphCollection">
-            <rdfs:label>Graph Collection</rdfs:label>
-            <rdfs:comment>An instance of sd:GraphCollection represents a collection of zero or more named graph descriptions. Each named graph description belonging to an sd:GraphCollection MUST be linked with the sd:namedGraph predicate.</rdfs:comment>
-          </rdfs:Class>
-        </rdfs:subClassOf>
-        <rdfs:label>Dataset</rdfs:label>
-        <rdfs:comment>An instance of sd:Dataset represents a RDF Dataset comprised of a default graph and zero or more named graphs.</rdfs:comment>
-      </rdfs:Class>
-    </rdfs:domain>
-    <rdfs:label>default graph</rdfs:label>
-    <rdfs:range>
-      <rdfs:Class rdf:about="http://www.w3.org/ns/sparql-service-description#Graph">
-        <rdfs:label>Graph</rdfs:label>
-        <rdfs:comment>An instance of sd:Graph represents the description of an RDF graph.</rdfs:comment>
-      </rdfs:Class>
-    </rdfs:range>
-    <rdfs:comment>Relates an instance of sd:Dataset to the description of its default graph.</rdfs:comment>
-  </rdf:Property>
-  <rdf:Property rdf:about="http://www.w3.org/ns/sparql-service-description#extensionAggregate">
-    <rdfs:label>extension aggregate</rdfs:label>
-    <rdfs:subPropertyOf>
-      <rdf:Property rdf:about="http://www.w3.org/ns/sparql-service-description#feature">
-        <rdfs:domain>
-          <rdfs:Class rdf:about="http://www.w3.org/ns/sparql-service-description#Service">
-            <rdfs:label>Service</rdfs:label>
-            <rdfs:comment>An instance of sd:Service represents a SPARQL service made available via the SPARQL Protocol.</rdfs:comment>
-          </rdfs:Class>
-        </rdfs:domain>
-        <rdfs:label>feature</rdfs:label>
-        <rdfs:range>
-          <rdfs:Class rdf:about="http://www.w3.org/ns/sparql-service-description#Feature">
-            <rdfs:label>Feature</rdfs:label>
-            <rdfs:comment>An instance of sd:Feature represents a feature of a SPARQL service. Specific types of features include functions, aggregates, languages, and entailment regimes and profiles. This document defines five instances of sd:Feature: sd:DereferencesURIs, sd:UnionDefaultGraph, sd:RequiresDataset, sd:EmptyGraphs, and sd:BasicFederatedQuery.</rdfs:comment>
-          </rdfs:Class>
-        </rdfs:range>
-        <rdfs:comment>Relates an instance of sd:Service with a resource representing a supported feature.</rdfs:comment>
-      </rdf:Property>
-    </rdfs:subPropertyOf>
-    <rdfs:domain rdf:resource="http://www.w3.org/ns/sparql-service-description#Service"/>
-    <rdfs:range>
-      <rdfs:Class rdf:about="http://www.w3.org/ns/sparql-service-description#Aggregate">
-        <rdfs:subClassOf rdf:resource="http://www.w3.org/ns/sparql-service-description#Feature"/>
-        <rdfs:label>Aggregate</rdfs:label>
-        <rdfs:comment>An instance of sd:Aggregate represents an aggregate that may be used in a SPARQL aggregate query (for instance in a HAVING clause or SELECT expression) besides the standard list of supported aggregates COUNT, SUM, MIN, MAX, AVG, GROUP_CONCAT, and SAMPLE.</rdfs:comment>
-      </rdfs:Class>
-    </rdfs:range>
-    <rdfs:comment>Relates an instance of sd:Service to an aggregate that may be used in a SPARQL aggregate query (for instance in a HAVING clause or SELECT expression) besides the standard list of supported aggregates COUNT, SUM, MIN, MAX, AVG, GROUP_CONCAT, and SAMPLE</rdfs:comment>
-  </rdf:Property>
-  <sd:Feature rdf:about="http://www.w3.org/ns/sparql-service-description#BasicFederatedQuery">
-    <rdfs:label>Basic Federated Query</rdfs:label>
-    <rdfs:comment>sd:BasicFederatedQuery, when used as the object of the sd:feature property, indicates that the SPARQL service supports basic federated query using the SERVICE keyword as defined by SPARQL 1.1 Federation Extensions.</rdfs:comment>
-  </sd:Feature>
-  <sd:Language rdf:about="http://www.w3.org/ns/sparql-service-description#SPARQL10Query">
-    <rdfs:label>SPARQL 1.0 Query</rdfs:label>
-    <rdfs:comment>sd:SPARQL10Query is an sd:Language representing the SPARQL 1.0 Query language.</rdfs:comment>
-  </sd:Language>
-  <rdf:Property rdf:about="http://www.w3.org/ns/sparql-service-description#defaultSupportedEntailmentProfile">
-    <rdfs:label>default supported entailment profile</rdfs:label>
-    <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/sparql-service-description#feature"/>
-    <rdfs:domain rdf:resource="http://www.w3.org/ns/sparql-service-description#Service"/>
-    <rdfs:range>
-      <rdfs:Class rdf:about="http://www.w3.org/ns/sparql-service-description#EntailmentProfile">
-        <rdfs:subClassOf rdf:resource="http://www.w3.org/ns/sparql-service-description#Feature"/>
-        <rdfs:label>Entailment Profile</rdfs:label>
-        <rdfs:comment>An instance of sd:EntailmentProfile represents a profile of an entailment regime. An entailment profile MAY impose restrictions on what constitutes valid RDF with respect to entailment.</rdfs:comment>
-      </rdfs:Class>
-    </rdfs:range>
-    <rdfs:comment>Relates an instance of sd:Service with a resource representing a supported profile of the default entailment regime (as declared by sd:defaultEntailmentRegime).</rdfs:comment>
-  </rdf:Property>
-  <sd:Feature rdf:about="http://www.w3.org/ns/sparql-service-description#DereferencesURIs">
-    <rdfs:label>Dereferences URIs</rdfs:label>
-    <rdfs:comment>sd:DereferencesURIs, when used as the object of the sd:feature property, indicates that a SPARQL service will dereference URIs used in FROM/FROM NAMED and USING/USING NAMED clauses and use the resulting RDF in the dataset during query evaluation.</rdfs:comment>
-  </sd:Feature>
-  <rdf:Property rdf:about="http://www.w3.org/ns/sparql-service-description#namedGraph">
-    <rdfs:domain rdf:resource="http://www.w3.org/ns/sparql-service-description#GraphCollection"/>
-    <rdfs:label>named graph</rdfs:label>
-    <rdfs:range rdf:resource="http://www.w3.org/ns/sparql-service-description#NamedGraph"/>
-    <rdfs:comment>Relates an instance of sd:GraphCollection (or its subclass sd:Dataset) to the description of one of its named graphs. The description of such a named graph MUST include the sd:name property and MAY include the sd:graph property.</rdfs:comment>
-  </rdf:Property>
-  <rdf:Property rdf:about="http://www.w3.org/ns/sparql-service-description#supportedLanguage">
-    <rdfs:label>supported language</rdfs:label>
-    <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/sparql-service-description#feature"/>
-    <rdfs:domain rdf:resource="http://www.w3.org/ns/sparql-service-description#Service"/>
-    <rdfs:range>
-      <rdfs:Class rdf:about="http://www.w3.org/ns/sparql-service-description#Language">
-        <rdfs:subClassOf rdf:resource="http://www.w3.org/ns/sparql-service-description#Feature"/>
-        <rdfs:label>Language</rdfs:label>
-        <rdfs:comment>An instance of sd:Language represents one of the SPARQL languages, including specific configurations providing particular features or extensions. This document defines three instances of sd:Language: sd:SPARQL10Query, sd:SPARQL11Query, and sd:SPARQL11Update.</rdfs:comment>
-      </rdfs:Class>
-    </rdfs:range>
-    <rdfs:comment>Relates an instance of sd:Service to a SPARQL language (e.g. Query and Update) that it implements.</rdfs:comment>
-  </rdf:Property>
-  <rdf:Property rdf:about="http://www.w3.org/ns/sparql-service-description#inputFormat">
-    <rdfs:domain rdf:resource="http://www.w3.org/ns/sparql-service-description#Service"/>
-    <rdfs:label>input format</rdfs:label>
-    <rdfs:range rdf:resource="http://www.w3.org/ns/formats/Format"/>
-    <rdfs:comment>Relates an instance of sd:Service to a format that is supported for parsing RDF input; for example, via a SPARQL 1.1 Update LOAD statement, or when URIs are dereferenced in FROM/FROM NAMED/USING/USING NAMED clauses.</rdfs:comment>
-  </rdf:Property>
-  <sd:Language rdf:about="http://www.w3.org/ns/sparql-service-description#SPARQL11Query">
-    <rdfs:label>SPARQL 1.1 Query</rdfs:label>
-    <rdfs:comment>sd:SPARQL11Query is an sd:Language representing the SPARQL 1.1 Query language.</rdfs:comment>
-  </sd:Language>
-  <rdf:Property rdf:about="http://www.w3.org/ns/sparql-service-description#languageExtension">
-    <rdfs:label>language extension</rdfs:label>
-    <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/sparql-service-description#feature"/>
-    <rdfs:domain rdf:resource="http://www.w3.org/ns/sparql-service-description#Service"/>
-    <rdfs:range rdf:resource="http://www.w3.org/ns/sparql-service-description#Feature"/>
-    <rdfs:comment>Relates an instance of sd:Service to a resource representing an implemented extension to the SPARQL Query or Update language.</rdfs:comment>
-  </rdf:Property>
-  <rdf:Property rdf:about="http://www.w3.org/ns/sparql-service-description#graph">
-    <rdfs:domain rdf:resource="http://www.w3.org/ns/sparql-service-description#NamedGraph"/>
-    <rdfs:label>graph</rdfs:label>
-    <rdfs:range rdf:resource="http://www.w3.org/ns/sparql-service-description#Graph"/>
-    <rdfs:comment>Relates a named graph to its graph description.</rdfs:comment>
-  </rdf:Property>
-  <rdf:Property rdf:about="http://www.w3.org/ns/sparql-service-description#propertyFeature">
-    <rdfs:label>property feature</rdfs:label>
-    <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/sparql-service-description#feature"/>
-    <rdfs:domain rdf:resource="http://www.w3.org/ns/sparql-service-description#Service"/>
-    <rdfs:range rdf:resource="http://www.w3.org/ns/sparql-service-description#Feature"/>
-    <rdfs:comment>Relates an instance of sd:Service to a resource representing an implemented feature that extends the SPARQL Query or Update language and that is accessed by using the named property.</rdfs:comment>
-  </rdf:Property>
-  <rdf:Property rdf:about="http://www.w3.org/ns/sparql-service-description#defaultEntailmentRegime">
-    <rdfs:label>default entailment regime</rdfs:label>
-    <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/sparql-service-description#feature"/>
-    <rdfs:domain rdf:resource="http://www.w3.org/ns/sparql-service-description#Service"/>
-    <rdfs:range>
-      <rdfs:Class rdf:about="http://www.w3.org/ns/sparql-service-description#EntailmentRegime">
-        <rdfs:subClassOf rdf:resource="http://www.w3.org/ns/sparql-service-description#Feature"/>
-        <rdfs:label>Entailment Regime</rdfs:label>
-        <rdfs:comment>An instance of sd:EntailmentRegime represents an entailment regime used in basic graph pattern matching (as described by SPARQL 1.1 Query Language).</rdfs:comment>
-      </rdfs:Class>
-    </rdfs:range>
-    <rdfs:comment>Relates an instance of sd:Service with a resource representing an entailment regime used for basic graph pattern matching. This property is intended for use when a single entailment regime by default applies to all graphs in the default dataset of the service. In situations where a different entailment regime applies to a specific graph in the dataset, the sd:entailmentRegime property should be used to indicate this fact in the description of that graph.</rdfs:comment>
-  </rdf:Property>
-  <rdf:Property rdf:about="http://www.w3.org/ns/sparql-service-description#resultFormat">
-    <rdfs:domain rdf:resource="http://www.w3.org/ns/sparql-service-description#Service"/>
-    <rdfs:label>result format</rdfs:label>
-    <rdfs:range rdf:resource="http://www.w3.org/ns/formats/Format"/>
-    <rdfs:comment>Relates an instance of sd:Service to a format that is supported for serializing query results.</rdfs:comment>
-  </rdf:Property>
-  <rdf:Property rdf:about="http://www.w3.org/ns/sparql-service-description#entailmentRegime">
-    <rdfs:domain rdf:resource="http://www.w3.org/ns/sparql-service-description#NamedGraph"/>
-    <rdfs:label>entailment regime</rdfs:label>
-    <rdfs:range rdf:resource="http://www.w3.org/ns/sparql-service-description#EntailmentRegime"/>
-    <rdfs:comment>Relates a named graph description with a resource representing an entailment regime used for basic graph pattern matching over that graph.</rdfs:comment>
-  </rdf:Property>
-  <sd:Language rdf:about="http://www.w3.org/ns/sparql-service-description#SPARQL11Update">
-    <rdfs:label>SPARQL 1.1 Update</rdfs:label>
-    <rdfs:comment>sd:SPARQLUpdate is an sd:Language representing the SPARQL 1.1 Update language.</rdfs:comment>
-  </sd:Language>
-  <rdf:Property rdf:about="http://www.w3.org/ns/sparql-service-description#availableGraphs">
-    <rdfs:domain rdf:resource="http://www.w3.org/ns/sparql-service-description#Service"/>
-    <rdfs:label>available graph descriptions</rdfs:label>
-    <rdfs:range rdf:resource="http://www.w3.org/ns/sparql-service-description#GraphCollection"/>
-    <rdfs:comment>Relates an instance of sd:Service to a description of the graphs which are allowed in the construction of a dataset either via the SPARQL Protocol, with FROM/FROM NAMED clauses in a query, or with USING/USING NAMED in an update request, if the service limits the scope of dataset construction.</rdfs:comment>
-  </rdf:Property>
-  <sd:Feature rdf:about="http://www.w3.org/ns/sparql-service-description#RequiresDataset">
-    <rdfs:label>Requires Dataset</rdfs:label>
-    <rdfs:comment>sd:RequiresDataset, when used as the object of the sd:feature property, indicates that the SPARQL service requires an explicit dataset declaration (based on either FROM/FROM NAMED clauses in a query, USING/USING NAMED clauses in an update, or the appropriate SPARQL Protocol parameters).</rdfs:comment>
-  </sd:Feature>
-  <rdf:Property rdf:about="http://www.w3.org/ns/sparql-service-description#defaultDataset">
-    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#InverseFunctionalProperty"/>
-    <rdfs:domain rdf:resource="http://www.w3.org/ns/sparql-service-description#Service"/>
-    <rdfs:label>default dataset description</rdfs:label>
-    <rdfs:range rdf:resource="http://www.w3.org/ns/sparql-service-description#Dataset"/>
-    <rdfs:comment>Relates an instance of sd:Service to a description of the default dataset available when no explicit dataset is specified in the query, update request or via protocol parameters.</rdfs:comment>
-  </rdf:Property>
   <rdf:Property rdf:about="http://www.w3.org/ns/sparql-service-description#endpoint">
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#InverseFunctionalProperty"/>
     <rdfs:domain rdf:resource="http://www.w3.org/ns/sparql-service-description#Service"/>
     <rdfs:label>endpoint</rdfs:label>
     <rdfs:comment>The SPARQL endpoint of an sd:Service that implements the SPARQL Protocol service. The object of the sd:endpoint property is an IRI.</rdfs:comment>
   </rdf:Property>
-  <rdf:Property rdf:about="http://www.w3.org/ns/sparql-service-description#extensionFunction">
-    <rdfs:label>extension function</rdfs:label>
+  <rdf:Property rdf:about="http://www.w3.org/ns/sparql-service-description#feature">
+    <rdfs:domain rdf:resource="http://www.w3.org/ns/sparql-service-description#Service"/>
+    <rdfs:range rdf:resource="http://www.w3.org/ns/sparql-service-description#Feature"/>
+    <rdfs:label>feature</rdfs:label>
+    <rdfs:comment>Relates an instance of sd:Service with a resource representing a supported feature.</rdfs:comment>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.w3.org/ns/sparql-service-description#defaultEntailmentRegime">
     <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/sparql-service-description#feature"/>
     <rdfs:domain rdf:resource="http://www.w3.org/ns/sparql-service-description#Service"/>
-    <rdfs:range>
-      <rdfs:Class rdf:about="http://www.w3.org/ns/sparql-service-description#Function">
-        <rdfs:subClassOf rdf:resource="http://www.w3.org/ns/sparql-service-description#Feature"/>
-        <rdfs:label>Function</rdfs:label>
-        <rdfs:comment>An instance of sd:Function represents a function that may be used in a SPARQL SELECT expression or a FILTER, HAVING, GROUP BY, ORDER BY, or BIND clause.</rdfs:comment>
-      </rdfs:Class>
-    </rdfs:range>
-    <rdfs:comment>Relates an instance of sd:Service to a function that may be used in a SPARQL SELECT expression or a FILTER, HAVING, GROUP BY, ORDER BY, or BIND clause.</rdfs:comment>
+    <rdfs:range rdf:resource="http://www.w3.org/ns/sparql-service-description#EntailmentRegime"/>
+    <rdfs:label>default entailment regime</rdfs:label>
+    <rdfs:comment>Relates an instance of sd:Service with a resource representing an entailment regime used for basic graph pattern matching. This property is intended for use when a single entailment regime by default applies to all graphs in the default dataset of the service. In situations where a different entailment regime applies to a specific graph in the dataset, the sd:entailmentRegime property should be used to indicate this fact in the description of that graph.</rdfs:comment>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.w3.org/ns/sparql-service-description#entailmentRegime">
+    <rdfs:domain rdf:resource="http://www.w3.org/ns/sparql-service-description#NamedGraph"/>
+    <rdfs:range rdf:resource="http://www.w3.org/ns/sparql-service-description#EntailmentRegime"/>
+    <rdfs:label>entailment regime</rdfs:label>
+    <rdfs:comment>Relates a named graph description with a resource representing an entailment regime used for basic graph pattern matching over that graph.</rdfs:comment>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.w3.org/ns/sparql-service-description#defaultSupportedEntailmentProfile">
+    <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/sparql-service-description#feature"/>
+    <rdfs:domain rdf:resource="http://www.w3.org/ns/sparql-service-description#Service"/>
+    <rdfs:range rdf:resource="http://www.w3.org/ns/sparql-service-description#EntailmentProfile"/>
+    <rdfs:label>default supported entailment profile</rdfs:label>
+    <rdfs:comment>Relates an instance of sd:Service with a resource representing a supported profile of the default entailment regime (as declared by sd:defaultEntailmentRegime).</rdfs:comment>
   </rdf:Property>
   <rdf:Property rdf:about="http://www.w3.org/ns/sparql-service-description#supportedEntailmentProfile">
     <rdfs:domain rdf:resource="http://www.w3.org/ns/sparql-service-description#NamedGraph"/>
-    <rdfs:label>supported entailment profile</rdfs:label>
     <rdfs:range rdf:resource="http://www.w3.org/ns/sparql-service-description#EntailmentProfile"/>
+    <rdfs:label>supported entailment profile</rdfs:label>
     <rdfs:comment>Relates a named graph description with a resource representing a supported profile of the entailment regime (as declared by sd:entailmentRegime) used for basic graph pattern matching over that graph.</rdfs:comment>
   </rdf:Property>
+  <rdf:Property rdf:about="http://www.w3.org/ns/sparql-service-description#extensionFunction">
+    <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/sparql-service-description#feature"/>
+    <rdfs:domain rdf:resource="http://www.w3.org/ns/sparql-service-description#Service"/>
+    <rdfs:range rdf:resource="http://www.w3.org/ns/sparql-service-description#Function"/>
+    <rdfs:label>extension function</rdfs:label>
+    <rdfs:comment>Relates an instance of sd:Service to a function that may be used in a SPARQL SELECT expression or a FILTER, HAVING, GROUP BY, ORDER BY, or BIND clause.</rdfs:comment>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.w3.org/ns/sparql-service-description#extensionAggregate">
+    <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/sparql-service-description#feature"/>
+    <rdfs:domain rdf:resource="http://www.w3.org/ns/sparql-service-description#Service"/>
+    <rdfs:range rdf:resource="http://www.w3.org/ns/sparql-service-description#Aggregate"/>
+    <rdfs:label>extension aggregate</rdfs:label>
+    <rdfs:comment>Relates an instance of sd:Service to an aggregate that may be used in a SPARQL aggregate query (for instance in a HAVING clause or SELECT expression) besides the standard list of supported aggregates COUNT, SUM, MIN, MAX, AVG, GROUP_CONCAT, and SAMPLE</rdfs:comment>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.w3.org/ns/sparql-service-description#languageExtension">
+    <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/sparql-service-description#feature"/>
+    <rdfs:domain rdf:resource="http://www.w3.org/ns/sparql-service-description#Service"/>
+    <rdfs:range rdf:resource="http://www.w3.org/ns/sparql-service-description#Feature"/>
+    <rdfs:label>language extension</rdfs:label>
+    <rdfs:comment>Relates an instance of sd:Service to a resource representing an implemented extension to the SPARQL Query or Update language.</rdfs:comment>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.w3.org/ns/sparql-service-description#supportedLanguage">
+    <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/sparql-service-description#feature"/>
+    <rdfs:domain rdf:resource="http://www.w3.org/ns/sparql-service-description#Service"/>
+    <rdfs:range rdf:resource="http://www.w3.org/ns/sparql-service-description#Language"/>
+    <rdfs:label>supported language</rdfs:label>
+    <rdfs:comment>Relates an instance of sd:Service to a SPARQL language (e.g. Query and Update) that it implements.</rdfs:comment>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.w3.org/ns/sparql-service-description#supportedVersion">
+    <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/sparql-service-description#feature"/>
+    <rdfs:domain rdf:resource="http://www.w3.org/ns/sparql-service-description#Service"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+    <rdfs:label>supported version</rdfs:label>
+    <rdfs:comment>Relates an instance of sd:Service to a SPARQL language version that it supports.</rdfs:comment>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.w3.org/ns/sparql-service-description#propertyFeature">
+    <rdfs:subPropertyOf rdf:resource="http://www.w3.org/ns/sparql-service-description#feature"/>
+    <rdfs:domain rdf:resource="http://www.w3.org/ns/sparql-service-description#Service"/>
+    <rdfs:range rdf:resource="http://www.w3.org/ns/sparql-service-description#Feature"/>
+    <rdfs:label>property feature</rdfs:label>
+    <rdfs:comment>Relates an instance of sd:Service to a resource representing an implemented feature that extends the SPARQL Query or Update language and that is accessed by using the named property.</rdfs:comment>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.w3.org/ns/sparql-service-description#defaultDataset">
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#InverseFunctionalProperty"/>
+    <rdfs:domain rdf:resource="http://www.w3.org/ns/sparql-service-description#Service"/>
+    <rdfs:range rdf:resource="http://www.w3.org/ns/sparql-service-description#Dataset"/>
+    <rdfs:label>default dataset description</rdfs:label>
+    <rdfs:comment>Relates an instance of sd:Service to a description of the default dataset available when no explicit dataset is specified in the query, update request or via protocol parameters.</rdfs:comment>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.w3.org/ns/sparql-service-description#availableGraphs">
+    <rdfs:domain rdf:resource="http://www.w3.org/ns/sparql-service-description#Service"/>
+    <rdfs:range rdf:resource="http://www.w3.org/ns/sparql-service-description#GraphCollection"/>
+    <rdfs:label>available graph descriptions</rdfs:label>
+    <rdfs:comment>Relates an instance of sd:Service to a description of the graphs which are allowed in the construction of a dataset either via the SPARQL Protocol, with FROM/FROM NAMED clauses in a query, or with USING/USING NAMED in an update request, if the service limits the scope of dataset construction.</rdfs:comment>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.w3.org/ns/sparql-service-description#resultFormat">
+    <rdfs:domain rdf:resource="http://www.w3.org/ns/sparql-service-description#Service"/>
+    <rdfs:range rdf:resource="http://www.w3.org/ns/formats/Format"/>
+    <rdfs:label>result format</rdfs:label>
+    <rdfs:comment>Relates an instance of sd:Service to a format that is supported for serializing query results.</rdfs:comment>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.w3.org/ns/sparql-service-description#inputFormat">
+    <rdfs:domain rdf:resource="http://www.w3.org/ns/sparql-service-description#Service"/>
+    <rdfs:range rdf:resource="http://www.w3.org/ns/formats/Format"/>
+    <rdfs:label>input format</rdfs:label>
+    <rdfs:comment>Relates an instance of sd:Service to a format that is supported for parsing RDF input; for example, via a SPARQL 1.1 Update LOAD statement, or when URIs are dereferenced in FROM/FROM NAMED/USING/USING NAMED clauses.</rdfs:comment>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.w3.org/ns/sparql-service-description#defaultGraph">
+    <rdfs:domain rdf:resource="http://www.w3.org/ns/sparql-service-description#Dataset"/>
+    <rdfs:range rdf:resource="http://www.w3.org/ns/sparql-service-description#Graph"/>
+    <rdfs:label>default graph</rdfs:label>
+    <rdfs:comment>Relates an instance of sd:Dataset to the description of its default graph.</rdfs:comment>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.w3.org/ns/sparql-service-description#namedGraph">
+    <rdfs:domain rdf:resource="http://www.w3.org/ns/sparql-service-description#GraphCollection"/>
+    <rdfs:range rdf:resource="http://www.w3.org/ns/sparql-service-description#NamedGraph"/>
+    <rdfs:label>named graph</rdfs:label>
+    <rdfs:comment>Relates an instance of sd:GraphCollection (or its subclass sd:Dataset) to the description of one of its named graphs. The description of such a named graph MUST include the sd:name property and MAY include the sd:graph property.</rdfs:comment>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.w3.org/ns/sparql-service-description#name">
+    <rdfs:domain rdf:resource="http://www.w3.org/ns/sparql-service-description#NamedGraph"/>
+    <rdfs:label>name</rdfs:label>
+    <rdfs:comment>Relates a named graph to the name by which it may be referenced in a FROM/FROM NAMED clause. The object of the sd:name property is an IRI.</rdfs:comment>
+  </rdf:Property>
+  <rdf:Property rdf:about="http://www.w3.org/ns/sparql-service-description#graph">
+    <rdfs:domain rdf:resource="http://www.w3.org/ns/sparql-service-description#NamedGraph"/>
+    <rdfs:range rdf:resource="http://www.w3.org/ns/sparql-service-description#Graph"/>
+    <rdfs:label>graph</rdfs:label>
+    <rdfs:comment>Relates a named graph to its graph description.</rdfs:comment>
+  </rdf:Property>
+  <rdfs:Class rdf:about="http://www.w3.org/ns/sparql-service-description#Service">
+    <rdfs:label>Service</rdfs:label>
+    <rdfs:comment>An instance of sd:Service represents a SPARQL service made available via the SPARQL Protocol.</rdfs:comment>
+  </rdfs:Class>
+  <rdfs:Class rdf:about="http://www.w3.org/ns/sparql-service-description#Feature">
+    <rdfs:label>Feature</rdfs:label>
+    <rdfs:comment>An instance of sd:Feature represents a feature of a SPARQL service. Specific types of features include functions, aggregates, languages, and entailment regimes and profiles. This document defines five instances of sd:Feature: sd:DereferencesURIs, sd:UnionDefaultGraph, sd:RequiresDataset, sd:EmptyGraphs, and sd:BasicFederatedQuery.</rdfs:comment>
+  </rdfs:Class>
+  <rdfs:Class rdf:about="http://www.w3.org/ns/sparql-service-description#Language">
+    <rdfs:subClassOf rdf:resource="http://www.w3.org/ns/sparql-service-description#Feature"/>
+    <rdfs:label>Language</rdfs:label>
+    <rdfs:comment>An instance of sd:Language represents one of the SPARQL languages, including specific configurations providing particular features or extensions. This document defines five instances of sd:Language: sd:SPARQLQuery, sd:SPARQLUpdate, sd:SPARQL10Query, sd:SPARQL11Query, and sd:SPARQL11Update.</rdfs:comment>
+  </rdfs:Class>
+  <rdfs:Class rdf:about="http://www.w3.org/ns/sparql-service-description#Function">
+    <rdfs:subClassOf rdf:resource="http://www.w3.org/ns/sparql-service-description#Feature"/>
+    <rdfs:label>Function</rdfs:label>
+    <rdfs:comment>An instance of sd:Function represents a function that may be used in a SPARQL SELECT expression or a FILTER, HAVING, GROUP BY, ORDER BY, or BIND clause.</rdfs:comment>
+  </rdfs:Class>
+  <rdfs:Class rdf:about="http://www.w3.org/ns/sparql-service-description#Aggregate">
+    <rdfs:subClassOf rdf:resource="http://www.w3.org/ns/sparql-service-description#Feature"/>
+    <rdfs:label>Aggregate</rdfs:label>
+    <rdfs:comment>An instance of sd:Aggregate represents an aggregate that may be used in a SPARQL aggregate query (for instance in a HAVING clause or SELECT expression) besides the standard list of supported aggregates COUNT, SUM, MIN, MAX, AVG, GROUP_CONCAT, and SAMPLE.</rdfs:comment>
+  </rdfs:Class>
+  <rdfs:Class rdf:about="http://www.w3.org/ns/sparql-service-description#EntailmentRegime">
+    <rdfs:subClassOf rdf:resource="http://www.w3.org/ns/sparql-service-description#Feature"/>
+    <rdfs:label>Entailment Regime</rdfs:label>
+    <rdfs:comment>An instance of sd:EntailmentRegime represents an entailment regime used in basic graph pattern matching (as described by SPARQL 1.1 Query Language).</rdfs:comment>
+  </rdfs:Class>
+  <rdfs:Class rdf:about="http://www.w3.org/ns/sparql-service-description#EntailmentProfile">
+    <rdfs:subClassOf rdf:resource="http://www.w3.org/ns/sparql-service-description#Feature"/>
+    <rdfs:label>Entailment Profile</rdfs:label>
+    <rdfs:comment>An instance of sd:EntailmentProfile represents a profile of an entailment regime. An entailment profile MAY impose restrictions on what constitutes valid RDF with respect to entailment.</rdfs:comment>
+  </rdfs:Class>
+  <rdfs:Class rdf:about="http://www.w3.org/ns/sparql-service-description#GraphCollection">
+    <rdfs:label>Graph Collection</rdfs:label>
+    <rdfs:comment>An instance of sd:GraphCollection represents a collection of zero or more named graph descriptions. Each named graph description belonging to an sd:GraphCollection MUST be linked with the sd:namedGraph predicate.</rdfs:comment>
+  </rdfs:Class>
+  <rdfs:Class rdf:about="http://www.w3.org/ns/sparql-service-description#Dataset">
+    <rdfs:subClassOf rdf:resource="http://www.w3.org/ns/sparql-service-description#GraphCollection"/>
+    <rdfs:label>Dataset</rdfs:label>
+    <rdfs:comment>An instance of sd:Dataset represents a RDF Dataset comprised of a default graph and zero or more named graphs.</rdfs:comment>
+  </rdfs:Class>
+  <rdfs:Class rdf:about="http://www.w3.org/ns/sparql-service-description#Graph">
+    <rdfs:label>Graph</rdfs:label>
+    <rdfs:comment>An instance of sd:Graph represents the description of an RDF graph.</rdfs:comment>
+  </rdfs:Class>
+  <rdfs:Class rdf:about="http://www.w3.org/ns/sparql-service-description#NamedGraph">
+    <rdfs:label>Named Graph</rdfs:label>
+    <rdfs:comment>An instance of sd:NamedGraph represents a named graph having a name (via sd:name) and an optional graph description (via sd:graph).</rdfs:comment>
+  </rdfs:Class>
+  <sd:Language rdf:about="http://www.w3.org/ns/sparql-service-description#SPARQLQuery">
+    <rdfs:label>SPARQL Query</rdfs:label>
+    <rdfs:comment>sd:SPARQLQuery is an sd:Language representing the SPARQL Query language.</rdfs:comment>
+  </sd:Language>
+  <sd:Language rdf:about="http://www.w3.org/ns/sparql-service-description#SPARQL10Query">
+    <rdfs:label>SPARQL 1.0 Query</rdfs:label>
+    <rdfs:comment>sd:SPARQL10Query is an sd:Language representing the SPARQL 1.0 Query language.</rdfs:comment>
+  </sd:Language>
+  <sd:Language rdf:about="http://www.w3.org/ns/sparql-service-description#SPARQL11Query">
+    <rdfs:label>SPARQL 1.1 Query</rdfs:label>
+    <rdfs:comment>sd:SPARQL11Query is an sd:Language representing the SPARQL 1.1 Query language.</rdfs:comment>
+  </sd:Language>
+  <sd:Language rdf:about="http://www.w3.org/ns/sparql-service-description#SPARQLUpdate">
+    <rdfs:label>SPARQL Update</rdfs:label>
+    <rdfs:comment>sd:SPARQLUpdate is an sd:Language representing the SPARQL Update language.</rdfs:comment>
+  </sd:Language>
+  <sd:Language rdf:about="http://www.w3.org/ns/sparql-service-description#SPARQL11Update">
+    <rdfs:label>SPARQL 1.1 Update</rdfs:label>
+    <rdfs:comment>sd:SPARQLUpdate is an sd:Language representing the SPARQL 1.1 Update language.</rdfs:comment>
+  </sd:Language>
+  <sd:Feature rdf:about="http://www.w3.org/ns/sparql-service-description#DereferencesURIs">
+    <rdfs:label>Dereferences URIs</rdfs:label>
+    <rdfs:comment>sd:DereferencesURIs, when used as the object of the sd:feature property, indicates that a SPARQL service will dereference URIs used in FROM/FROM NAMED and USING/USING NAMED clauses and use the resulting RDF in the dataset during query evaluation.</rdfs:comment>
+  </sd:Feature>
+  <sd:Feature rdf:about="http://www.w3.org/ns/sparql-service-description#UnionDefaultGraph">
+    <rdfs:label>Union Default Graph</rdfs:label>
+    <rdfs:comment>sd:UnionDefaultGraph, when used as the object of the sd:feature property, indicates that the default graph of the dataset used during query and update evaluation (when an explicit dataset is not specified) is comprised of the union of all the named graphs in that dataset.</rdfs:comment>
+  </sd:Feature>
+  <sd:Feature rdf:about="http://www.w3.org/ns/sparql-service-description#RequiresDataset">
+    <rdfs:label>Requires Dataset</rdfs:label>
+    <rdfs:comment>sd:RequiresDataset, when used as the object of the sd:feature property, indicates that the SPARQL service requires an explicit dataset declaration (based on either FROM/FROM NAMED clauses in a query, USING/USING NAMED clauses in an update, or the appropriate SPARQL Protocol parameters).</rdfs:comment>
+  </sd:Feature>
+  <sd:Feature rdf:about="http://www.w3.org/ns/sparql-service-description#EmptyGraphs">
+    <rdfs:label>Empty Graphs</rdfs:label>
+    <rdfs:comment>sd:EmptyGraphs, when used as the object of the sd:feature property, indicates that the underlying graph store supports empty graphs. A graph store that supports empty graphs MUST NOT remove graphs that are left empty after triples are removed from them.</rdfs:comment>
+  </sd:Feature>
+  <sd:Feature rdf:about="http://www.w3.org/ns/sparql-service-description#BasicFederatedQuery">
+    <rdfs:label>Basic Federated Query</rdfs:label>
+    <rdfs:comment>sd:BasicFederatedQuery, when used as the object of the sd:feature property, indicates that the SPARQL service supports basic federated query using the SERVICE keyword as defined by SPARQL 1.1 Federation Extensions.</rdfs:comment>
+  </sd:Feature>
 </rdf:RDF>

--- a/sparql-service-description.ttl
+++ b/sparql-service-description.ttl
@@ -70,6 +70,13 @@ sd:supportedLanguage a rdf:Property ;
 	rdfs:label "supported language" ;
 	rdfs:comment "Relates an instance of sd:Service to a SPARQL language (e.g. Query and Update) that it implements." .
 
+sd:supportedVersion a rdf:Property ;
+	rdfs:subPropertyOf sd:feature ;
+	rdfs:domain sd:Service ;
+	rdfs:range rdfs:Resource ;
+	rdfs:label "supported version" ;
+	rdfs:comment "Relates an instance of sd:Service to a SPARQL language version that it supports." .
+
 sd:propertyFeature a rdf:Property ;
 	rdfs:subPropertyOf sd:feature ;
 	rdfs:domain sd:Service ;
@@ -137,7 +144,7 @@ sd:Feature a rdfs:Class ;
 sd:Language a rdfs:Class ;
 	rdfs:subClassOf sd:Feature ;
 	rdfs:label "Language" ;
-	rdfs:comment "An instance of sd:Language represents one of the SPARQL languages, including specific configurations providing particular features or extensions. This document defines three instances of sd:Language: sd:SPARQL10Query, sd:SPARQL11Query, and sd:SPARQL11Update." .
+	rdfs:comment "An instance of sd:Language represents one of the SPARQL languages, including specific configurations providing particular features or extensions. This document defines five instances of sd:Language: sd:SPARQLQuery, sd:SPARQLUpdate, sd:SPARQL10Query, sd:SPARQL11Query, and sd:SPARQL11Update." .
 
 sd:Function a rdfs:Class ;
 	rdfs:subClassOf sd:Feature ;
@@ -178,6 +185,10 @@ sd:NamedGraph a rdfs:Class ;
 	
 ### Instances
 
+sd:SPARQLQuery a sd:Language ;
+	rdfs:label "SPARQL Query" ;
+	rdfs:comment "sd:SPARQLQuery is an sd:Language representing the SPARQL Query language." .
+
 sd:SPARQL10Query a sd:Language ;
 	rdfs:label "SPARQL 1.0 Query" ;
 	rdfs:comment "sd:SPARQL10Query is an sd:Language representing the SPARQL 1.0 Query language." .
@@ -185,6 +196,10 @@ sd:SPARQL10Query a sd:Language ;
 sd:SPARQL11Query a sd:Language ;
 	rdfs:label "SPARQL 1.1 Query" ;
 	rdfs:comment "sd:SPARQL11Query is an sd:Language representing the SPARQL 1.1 Query language." .
+
+sd:SPARQLUpdate a sd:Language ;
+	rdfs:label "SPARQL Update" ;
+	rdfs:comment "sd:SPARQLUpdate is an sd:Language representing the SPARQL Update language." .
 
 sd:SPARQL11Update a sd:Language ;
 	rdfs:label "SPARQL 1.1 Update" ;


### PR DESCRIPTION
Updated Turtle and RDF/XML data to match the changes introduced in w3c/sparql-service-description#46.

Note the RDF/XML version shows a large diff here because I made changes in the Turtle file and then transcoded that file to RDF/XML, resulting in a very different serialization.