### PR TITLE
Updated some EPUB namespace references that were 404

### DIFF
--- a/epub/2007/opf/index.html
+++ b/epub/2007/opf/index.html
@@ -12,7 +12,7 @@
 
 		<h1>OPF Namespace</h1>
 
-		<p>The namespace name <code>http://www.idpf.org/2007/opf</code> is used in the <a href="https://www.w3.org/TR/epub/#sec-package-doc">EPUB 3</a> specification.</p>
+		<p>The namespace name <code>http://www.idpf.org/2007/opf</code> is defined in the <a href="https://www.w3.org/TR/epub/#sec-package-doc">EPUB 3</a> specification and also used in the <a href="https://www.w3.org/TR/epub-rs/">EPUB Reading Systems 3</a> specification.</p>
 
 		<p>For more information about the development of EPUB, refer to <a href="https://www.w3.org/publishing/">Publishing@W3C</a>.</p>
 

--- a/epub/2007/opf/index.html
+++ b/epub/2007/opf/index.html
@@ -12,7 +12,9 @@
 
 		<h1>OPF Namespace</h1>
 
-		<p>The namespace name <code>http://www.idpf.org/2007/opf</code> is defined in the <a href="https://www.w3.org/TR/epub/#sec-package-doc">EPUB 3</a> specification and also used in the <a href="https://www.w3.org/TR/epub-rs/">EPUB Reading Systems 3</a> specification.</p>
+		<p>The namespace name <code>http://www.idpf.org/2007/opf</code> is defined in the
+            <a href="https://www.w3.org/TR/epub/#sec-package-doc">EPUB 3</a> specification and also used in
+            the <a href="https://www.w3.org/TR/epub-rs/">EPUB Reading Systems 3</a> specification.</p>
 
 		<p>For more information about the development of EPUB, refer to <a href="https://www.w3.org/publishing/">Publishing@W3C</a>.</p>
 

--- a/epub/2007/opf/index.html
+++ b/epub/2007/opf/index.html
@@ -9,22 +9,13 @@
 		<div class="head">
 			<p><a href="https://www.w3.org/"><img class="head" src="https://www.w3.org/Icons/WWW/w3c_home" alt="W3C"></a></p>
 		</div>
-		
+
 		<h1>OPF Namespace</h1>
-		
-		<p>The namespace name <code>http://www.idpf.org/2007/opf</code> is used in the following EPUB specifications:</p>
-		
-		<ul>
-			<li>
-				<p><a href="http://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm">Open Publication Format 2.0.1</a></p>
-			</li>
-			<li>
-				<p><a href="https://www.w3.org/publishing/epub3/epub-packages.html">EPUB Packages 3</a></p>
-			</li>
-		</ul>
-		
+
+		<p>The namespace name <code>http://www.idpf.org/2007/opf</code> is used in the <a href="https://www.w3.org/TR/epub/#sec-package-doc">EPUB 3</a> specification.</p>
+
 		<p>For more information about the development of EPUB, refer to <a href="https://www.w3.org/publishing/">Publishing@W3C</a>.</p>
-		
+
 		<p>For more information about XML namespaces, refer to <a href="https://www.w3.org/TR/REC-xml-names/">Namespaces in XML</a>.</p>
 	</body>
 </html>

--- a/epub/2007/ops/index.html
+++ b/epub/2007/ops/index.html
@@ -12,7 +12,7 @@
 
 		<h1>OPS Namespace</h1>
 
-		<p>The namespace name <code>http://www.idpf.org/2007/ops</code> is used in the <a href="https://www.w3.org/TR/epub/#sec-intro-shorthands">EPUB 3</a> specification.</p>
+		<p>The namespace name <code>http://www.idpf.org/2007/ops</code> is defined in the <a href="https://www.w3.org/TR/epub/#sec-intro-shorthands">EPUB 3</a> specification and also used in the <a href="https://www.w3.org/TR/epub-rs/">EPUB Reading Systems 3</a> specification.</p>
 
 		<p>For more information about the development of EPUB, refer to <a href="https://www.w3.org/publishing/">Publishing@W3C</a>.</p>
 

--- a/epub/2007/ops/index.html
+++ b/epub/2007/ops/index.html
@@ -9,25 +9,13 @@
 		<div class="head">
 			<p><a href="https://www.w3.org/"><img class="head" src="https://www.w3.org/Icons/WWW/w3c_home" alt="W3C"></a></p>
 		</div>
-		
+
 		<h1>OPS Namespace</h1>
-		
-		<p>The namespace name <code>http://www.idpf.org/2007/ops</code> is used in the following EPUB specifications:</p>
-		
-		<ul>
-			<li>
-				<p><a href="http://idpf.org/epub/20/spec/OPS_2.0.1_draft.htm">Open Publication Structure 2.0.1</a></p>
-			</li>
-			<li>
-				<p><a href="https://www.w3.org/publishing/epub3/epub-contentdocs.html">EPUB Content Documents 3</a></p>
-			</li>
-			<li>
-				<p><a href="https://www.w3.org/publishing/epub3/epub-mediaoverlays.html">EPUB Media Overlays 3</a></p>
-			</li>
-		</ul>
-		
+
+		<p>The namespace name <code>http://www.idpf.org/2007/ops</code> is used in the <a href="https://www.w3.org/TR/epub/#sec-intro-shorthands">EPUB 3</a> specification.</p>
+
 		<p>For more information about the development of EPUB, refer to <a href="https://www.w3.org/publishing/">Publishing@W3C</a>.</p>
-		
+
 		<p>For more information about XML namespaces, refer to <a href="https://www.w3.org/TR/REC-xml-names/">Namespaces in XML</a>.</p>
 	</body>
 </html>

--- a/epub/2007/ops/index.html
+++ b/epub/2007/ops/index.html
@@ -12,7 +12,9 @@
 
 		<h1>OPS Namespace</h1>
 
-		<p>The namespace name <code>http://www.idpf.org/2007/ops</code> is defined in the <a href="https://www.w3.org/TR/epub/#sec-intro-shorthands">EPUB 3</a> specification and also used in the <a href="https://www.w3.org/TR/epub-rs/">EPUB Reading Systems 3</a> specification.</p>
+		<p>The namespace name <code>http://www.idpf.org/2007/ops</code> is defined in the
+            <a href="https://www.w3.org/TR/epub/#sec-intro-shorthands">EPUB 3</a> specification and also used
+            in the <a href="https://www.w3.org/TR/epub-rs/">EPUB Reading Systems 3</a> specification.</p>
 
 		<p>For more information about the development of EPUB, refer to <a href="https://www.w3.org/publishing/">Publishing@W3C</a>.</p>
 

--- a/epub/2008/embedding/index.html
+++ b/epub/2008/embedding/index.html
@@ -9,16 +9,17 @@
 		<div class="head">
 			<p><a href="https://www.w3.org/"><img class="head" src="https://www.w3.org/Icons/WWW/w3c_home" alt="W3C"></a></p>
 		</div>
-		
+
 		<h1>Embedding Identifier</h1>
-		
+
 		<p>The identifier <code>http://www.idpf.org/2008/embedding</code> signals the use of the
-		 	<a href="https://www.w3.org/publishing/epub3/epub-ocf.html#obfus-algorithm">Obfuscation Algorithm</a>
-					in EPUB 2 and 3 Publications.</p>
-		
-		<p>The algorithm was first defined in <a href="http://idpf.org/epub/20/spec/FontManglingSpec_2.0.1_draft.htm">Font Embedding 
+		 	<a href="https://www.w3.org/TR/epub-33/#sec-font-obfuscation">Obfuscation Algorithm</a>
+			in EPUB 2 and 3 Publications. Note that this algorithm was
+            <a href="https://www.w3.org/TR/epub-34/#sec-obs-conform">outdated in EPUB 3.4</a>.</p>
+
+		<p>The algorithm was first defined in <a href="http://idpf.org/epub/20/spec/FontManglingSpec_2.0.1_draft.htm">Font Embedding
 			for Open Container Format Files </a>
-		
+
 		<p>For more information about the development of EPUB, refer to <a href="https://www.w3.org/publishing/">Publishing@W3C</a>.</p>
 	</body>
 </html>

--- a/epub/2013/metadata/index.html
+++ b/epub/2013/metadata/index.html
@@ -9,19 +9,13 @@
 		<div class="head">
 			<p><a href="https://www.w3.org/"><img class="head" src="https://www.w3.org/Icons/WWW/w3c_home" alt="W3C"></a></p>
 		</div>
-		
+
 		<h1>Metadata Namespace</h1>
-		
-		<p>The namespace name <code>http://www.idpf.org/2013/metadata</code> is used in the following EPUB specifications:</p>
-		
-		<ul>
-			<li>
-				<p><a href="https://www.w3.org/publishing/epub3/epub-ocf.html">EPUB OCF 3</a></p>
-			</li>
-		</ul>
-		
+
+		<p>The namespace name <code>http://www.idpf.org/2013/metadata</code> is used in the <a href="https://www.w3.org/TR/epub/">EPUB 3</a> specification.</p>
+
 		<p>For more information about the development of EPUB, refer to <a href="https://www.w3.org/publishing/">Publishing@W3C</a>.</p>
-		
+
 		<p>For more information about XML namespaces, refer to <a href="https://www.w3.org/TR/REC-xml-names/">Namespaces in XML</a>.</p>
 	</body>
 </html>

--- a/epub/2016/encryption/index.html
+++ b/epub/2016/encryption/index.html
@@ -12,7 +12,7 @@
 
 		<h1>Encryption Namespace</h1>
 
-		<p>The namespace name <code>http://www.idpf.org/2016/encryption</code> is used iin the <a href="https://www.w3.org/TR/epub/">EPUB 3</a> specification (in the <a id="compression"><a href="https://www.w3.org/TR/epub/#elemdef-enc-Compression"><code>Compression</code> Element</a>).</p>
+		<p>The namespace name <code>http://www.idpf.org/2016/encryption</code> is used in the <a href="https://www.w3.org/TR/epub/">EPUB 3</a> specification (in the <a id="compression"><a href="https://www.w3.org/TR/epub/#elemdef-enc-Compression"><code>Compression</code> Element</a>).</p>
 
 		<p>For more information about the development of EPUB, refer to <a href="https://www.w3.org/publishing/">Publishing@W3C</a>.</p>
 

--- a/epub/2016/encryption/index.html
+++ b/epub/2016/encryption/index.html
@@ -9,22 +9,13 @@
 		<div class="head">
 			<p><a href="https://www.w3.org/"><img class="head" src="https://www.w3.org/Icons/WWW/w3c_home" alt="W3C"></a></p>
 		</div>
-		
+
 		<h1>Encryption Namespace</h1>
-		
-		<p>The namespace name <code>http://www.idpf.org/2016/encryption</code> is used in the following EPUB specifications:</p>
-		
-		<ul>
-			<li>
-				<p><a href="https://www.w3.org/publishing/epub3/epub-ocf.html">EPUB OCF 3</a></p>
-				<ul>
-					<li id="compression"><a href="https://www.w3.org/publishing/epub3/epub-ocf.html#elemdef-enc-Compression">The <code>Compression</code> Element</a></li>
-				</ul>
-			</li>
-		</ul>
-		
+
+		<p>The namespace name <code>http://www.idpf.org/2016/encryption</code> is used iin the <a href="https://www.w3.org/TR/epub/">EPUB 3</a> specification (in the <a id="compression"><a href="https://www.w3.org/TR/epub/#elemdef-enc-Compression"><code>Compression</code> Element</a>).</p>
+
 		<p>For more information about the development of EPUB, refer to <a href="https://www.w3.org/publishing/">Publishing@W3C</a>.</p>
-		
+
 		<p>For more information about XML namespaces, refer to <a href="https://www.w3.org/TR/REC-xml-names/">Namespaces in XML</a>.</p>
 	</body>
 </html>


### PR DESCRIPTION
The namespace documents for `http://www.idpf.org/2007/opf` and `http://www.idpf.org/2007/ops` were referring to long outdated specifications. Have changed them to reflect the new EPUB structure and using a stable (versionless) URL for the specification. 