### PR TITLE
Implement a SAML extension XSD to be used in the DBSC-SSO.

### DIFF
--- a/dbsc/saml
+++ b/dbsc/saml
@@ -1,1 +1,0 @@
-This is the namespace for the Device Bound Session Credentials for SSO specification. For further details, see: https://github.com/lucasrsant/dbsc-sso (update this link once we have a W3C editor's draft in place).

--- a/dbsc/saml/dbsc-saml.xsd
+++ b/dbsc/saml/dbsc-saml.xsd
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+	<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+             targetNamespace="https://www.w3.org/ns/dbsc/saml"
+             xmlns:dbsc="https://www.w3.org/ns/dbsc/saml"
+             elementFormDefault="qualified"
+             version="1.0">
+
+  <xs:annotation>
+    <xs:documentation>
+      XML Schema for Device Bound Session Credentials (DBSC) SAML Extensions.
+      As described in: https://github.com/WICG/dbsc-sso#saml-assertion-and-oidc-tokens
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:simpleType name="HashingAlgorithmType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="SHA-256"/>
+      <xs:enumeration value="SHA-384"/>
+      <xs:enumeration value="SHA-512"/>
+    </xs:restriction>
+  </xs:simpleType>
+	<xs:element name="TrustedKey">
+    <xs:annotation>
+      <xs:documentation>
+        The public key digest trusted by the Identity Provider issuing the SAML assertion.
+      </xs:documentation>
+    </xs:annotation>
+		<xs:complexType>
+			<xs:attribute name="digest" type="xs:base64Binary" use="required">
+			</xs:attribute>
+			<xs:attribute name="digest_alg" type="dbsc:HashingAlgorithmType" use="required">
+			</xs:attribute>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="TrustedCertificate">
+    <xs:annotation>
+      <xs:documentation>
+        The certificate fingerprint trusted by the Identity Provider issuing the SAML assertion.
+      </xs:documentation>
+    </xs:annotation>
+		<xs:complexType>
+			<xs:attribute name="fingerprint" type="xs:base64Binary" use="required">
+			</xs:attribute>
+			<xs:attribute name="fingerprint_alg" type="dbsc:HashingAlgorithmType" use="required">
+			</xs:attribute>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/dbsc/saml/index.html
+++ b/dbsc/saml/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <title>Device Bound Session Credentials (DBSC) for SAML Namespace</title>
+</head>
+<body>
+    <h1>Device Bound Session Credentials (DBSC) for SAML Namespace</h1>
+    <p>This is the namespace for the Device Bound Session Credentials for SSO specification (SAML extension).</p>
+    <p>For further details, see the explainer: <a href="https://github.com/WICG/dbsc-sso">https://github.com/WICG/dbsc-sso</a>.</p>
+    
+    <h2>XML Schema</h2>
+    <p>The XML Schema for this namespace can be found at: <a href="dbsc-saml.xsd">dbsc-saml.xsd</a>.</p>
+    
+    <hr />
+    <address>
+        W3C Device Bound Session Credentials (DBSC) Working Group / Community Group
+    </address>
+</body>
+</html>

--- a/dbsc/saml/sample-dbsc-saml-assertion.xml
+++ b/dbsc/saml/sample-dbsc-saml-assertion.xml
@@ -1,0 +1,42 @@
+<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="_8e8dc5f69a98cc4c1ff3427e5ce34606fd672f91e6" Version="2.0" IssueInstant="2014-07-17T01:01:48Z" Destination="http://sp.example.com/demo1/index.php?acs" InResponseTo="ONELOGIN_4fee3b046395c4e751011e97f8900b5273d56685">
+  <saml:Issuer>http://idp.example.com/metadata.php</saml:Issuer>
+  <samlp:Status>
+    <samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
+  </samlp:Status>
+  <saml:Assertion xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema" ID="_d71a3a8e9fcc45c9e9d248ef7049393fc8f04e5f75" Version="2.0" IssueInstant="2014-07-17T01:01:48Z">
+    <saml:Issuer>http://idp.example.com/metadata.php</saml:Issuer>
+    <saml:Subject>
+      <saml:NameID SPNameQualifier="http://sp.example.com/demo1/metadata.php" Format="urn:oasis:names:tc:SAML:2.0:nameid-format:transient">_ce3d2948b4cf20146dee0a0b3dd6f69b6cf86f62d7</saml:NameID>
+      <saml:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
+        <saml:SubjectConfirmationData NotOnOrAfter="2024-01-18T06:21:48Z" Recipient="http://sp.example.com/demo1/index.php?acs" InResponseTo="ONELOGIN_4fee3b046395c4e751011e97f8900b5273d56685"/>
+      </saml:SubjectConfirmation>
+    </saml:Subject>
+    <saml:Conditions NotBefore="2014-07-17T01:01:18Z" NotOnOrAfter="2024-01-18T06:21:48Z">
+      <saml:AudienceRestriction>
+        <saml:Audience>http://sp.example.com/demo1/metadata.php</saml:Audience>
+      </saml:AudienceRestriction>
+    </saml:Conditions>
+    <saml:AuthnStatement AuthnInstant="2014-07-17T01:01:48Z" SessionNotOnOrAfter="2024-07-17T09:01:48Z" SessionIndex="_be9967abd904ddcae3c0eb4189adbe3f71e327cf93">
+      <saml:AuthnContext>
+        <saml:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:Password</saml:AuthnContextClassRef>
+      </saml:AuthnContext>
+    </saml:AuthnStatement>
+    <saml:AttributeStatement>
+      <saml:Attribute Name="uid" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:basic">
+        <saml:AttributeValue xsi:type="xs:string">test</saml:AttributeValue>
+      </saml:Attribute>
+      <saml:Attribute Name="mail" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:basic">
+        <saml:AttributeValue xsi:type="xs:string">test@example.com</saml:AttributeValue>
+      </saml:Attribute>
+      <saml:Attribute Name="eduPersonAffiliation" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:basic">
+        <saml:AttributeValue xsi:type="xs:string">users</saml:AttributeValue>
+        <saml:AttributeValue xsi:type="xs:string">examplerole1</saml:AttributeValue>
+      </saml:Attribute>
+    </saml:AttributeStatement>
+    <saml:Advice>
+        <dbsc:TrustedCertificate xmlns:dbsc="http://www.w3.org/ns/dbsc/saml"
+            fingerptint="f3e9619a9d701a52701469e4f83d32847b2374e2593f66d48b788647097c234b"
+            fingerprint_alg="SHA_256" />
+    </saml:Advice>
+  </saml:Assertion>
+</samlp:Response>


### PR DESCRIPTION
This pull request implements a SAML extension XSD as part of the [DBSC-SSO](https://github.com/wicg/dbsc-sso). 

It defines how TPM|Secure Enclave key digests or certificate fingerprints should be passed to the Relying Party via SAML assertion using the `<saml:Advice>` element.