### PR TITLE
Add Base64URL restriction to share key digests and certificates fingerprint.

### DIFF
--- a/dbsc/saml/dbsc-saml.xsd
+++ b/dbsc/saml/dbsc-saml.xsd
@@ -32,9 +32,11 @@
     </xs:annotation>
 		<xs:complexType>
 			<xs:attribute name="digest" type="dbsc:Base64URL" use="required">
-        <xs:documentation>
-          The base64url-encoded (https://datatracker.ietf.org/doc/html/rfc4648#section-5) key digest.
-        </xs:documentation>
+        <xs:annotation>
+          <xs:documentation>
+            The base64url-encoded (https://datatracker.ietf.org/doc/html/rfc4648#section-5) key digest.
+          </xs:documentation>
+        </xs:annotation>
 			</xs:attribute>
 			<xs:attribute name="digest_alg" type="dbsc:HashingAlgorithmType" use="required">
 			</xs:attribute>
@@ -48,9 +50,11 @@
     </xs:annotation>
 		<xs:complexType>
 			<xs:attribute name="fingerprint" type="dbsc:Base64URL" use="required">
-        <xs:documentation>
-          The base64url-encoded (https://datatracker.ietf.org/doc/html/rfc4648#section-5) certificate fingerprint.
-        </xs:documentation>
+        <xs:annotation>
+          <xs:documentation>
+            The base64url-encoded (https://datatracker.ietf.org/doc/html/rfc4648#section-5) certificate fingerprint.
+          </xs:documentation>
+        </xs:annotation>
 			</xs:attribute>
 			<xs:attribute name="fingerprint_alg" type="dbsc:HashingAlgorithmType" use="required">
 			</xs:attribute>

--- a/dbsc/saml/dbsc-saml.xsd
+++ b/dbsc/saml/dbsc-saml.xsd
@@ -19,6 +19,11 @@
       <xs:enumeration value="SHA-512"/>
     </xs:restriction>
   </xs:simpleType>
+  <xs:simpleType name="Base64URL">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[A-Za-z0-9\-_]*(=(=)?)?" />
+    </xs:restriction>
+  </xs:simpleType>
 	<xs:element name="TrustedKey">
     <xs:annotation>
       <xs:documentation>
@@ -26,7 +31,10 @@
       </xs:documentation>
     </xs:annotation>
 		<xs:complexType>
-			<xs:attribute name="digest" type="xs:base64Binary" use="required">
+			<xs:attribute name="digest" type="dbsc:Base64URL" use="required">
+        <xs:documentation>
+          The base64url-encoded (https://datatracker.ietf.org/doc/html/rfc4648#section-5) key digest.
+        </xs:documentation>
 			</xs:attribute>
 			<xs:attribute name="digest_alg" type="dbsc:HashingAlgorithmType" use="required">
 			</xs:attribute>
@@ -39,7 +47,10 @@
       </xs:documentation>
     </xs:annotation>
 		<xs:complexType>
-			<xs:attribute name="fingerprint" type="xs:base64Binary" use="required">
+			<xs:attribute name="fingerprint" type="dbsc:Base64URL" use="required">
+        <xs:documentation>
+          The base64url-encoded (https://datatracker.ietf.org/doc/html/rfc4648#section-5) certificate fingerprint.
+        </xs:documentation>
 			</xs:attribute>
 			<xs:attribute name="fingerprint_alg" type="dbsc:HashingAlgorithmType" use="required">
 			</xs:attribute>

--- a/dbsc/saml/dbsc-saml.xsd
+++ b/dbsc/saml/dbsc-saml.xsd
@@ -19,6 +19,11 @@
       <xs:enumeration value="SHA-512"/>
     </xs:restriction>
   </xs:simpleType>
+  <xs:simpleType name="Base64URL">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[A-Za-z0-9\-_]*(=(=)?)?" />
+    </xs:restriction>
+  </xs:simpleType>
 	<xs:element name="TrustedKey">
     <xs:annotation>
       <xs:documentation>
@@ -26,7 +31,7 @@
       </xs:documentation>
     </xs:annotation>
 		<xs:complexType>
-			<xs:attribute name="digest" type="xs:base64Binary" use="required">
+			<xs:attribute name="digest" type="dbsc:Base64URL" use="required">
 			</xs:attribute>
 			<xs:attribute name="digest_alg" type="dbsc:HashingAlgorithmType" use="required">
 			</xs:attribute>
@@ -39,7 +44,7 @@
       </xs:documentation>
     </xs:annotation>
 		<xs:complexType>
-			<xs:attribute name="fingerprint" type="xs:base64Binary" use="required">
+			<xs:attribute name="fingerprint" type="dbsc:Base64URL" use="required">
 			</xs:attribute>
 			<xs:attribute name="fingerprint_alg" type="dbsc:HashingAlgorithmType" use="required">
 			</xs:attribute>

--- a/dbsc/saml/sample-dbsc-saml-assertion.xml
+++ b/dbsc/saml/sample-dbsc-saml-assertion.xml
@@ -1,42 +1,73 @@
-<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="_8e8dc5f69a98cc4c1ff3427e5ce34606fd672f91e6" Version="2.0" IssueInstant="2014-07-17T01:01:48Z" Destination="http://sp.example.com/demo1/index.php?acs" InResponseTo="ONELOGIN_4fee3b046395c4e751011e97f8900b5273d56685">
-  <saml:Issuer>http://idp.example.com/metadata.php</saml:Issuer>
-  <samlp:Status>
-    <samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
-  </samlp:Status>
-  <saml:Assertion xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema" ID="_d71a3a8e9fcc45c9e9d248ef7049393fc8f04e5f75" Version="2.0" IssueInstant="2014-07-17T01:01:48Z">
+<samlp:Response
+    xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+    xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
+    Destination="http://sp.example.com/demo1/index.php?acs"
+    ID="_8e8dc5f69a98cc4c1ff3427e5ce34606fd672f91e6"
+    InResponseTo="ONELOGIN_4fee3b046395c4e751011e97f8900b5273d56685"
+    IssueInstant="2014-07-17T01:01:48Z"
+    Version="2.0">
     <saml:Issuer>http://idp.example.com/metadata.php</saml:Issuer>
-    <saml:Subject>
-      <saml:NameID SPNameQualifier="http://sp.example.com/demo1/metadata.php" Format="urn:oasis:names:tc:SAML:2.0:nameid-format:transient">_ce3d2948b4cf20146dee0a0b3dd6f69b6cf86f62d7</saml:NameID>
-      <saml:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
-        <saml:SubjectConfirmationData NotOnOrAfter="2024-01-18T06:21:48Z" Recipient="http://sp.example.com/demo1/index.php?acs" InResponseTo="ONELOGIN_4fee3b046395c4e751011e97f8900b5273d56685"/>
-      </saml:SubjectConfirmation>
-    </saml:Subject>
-    <saml:Conditions NotBefore="2014-07-17T01:01:18Z" NotOnOrAfter="2024-01-18T06:21:48Z">
-      <saml:AudienceRestriction>
-        <saml:Audience>http://sp.example.com/demo1/metadata.php</saml:Audience>
-      </saml:AudienceRestriction>
-    </saml:Conditions>
-    <saml:AuthnStatement AuthnInstant="2014-07-17T01:01:48Z" SessionNotOnOrAfter="2024-07-17T09:01:48Z" SessionIndex="_be9967abd904ddcae3c0eb4189adbe3f71e327cf93">
-      <saml:AuthnContext>
-        <saml:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:Password</saml:AuthnContextClassRef>
-      </saml:AuthnContext>
-    </saml:AuthnStatement>
-    <saml:AttributeStatement>
-      <saml:Attribute Name="uid" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:basic">
-        <saml:AttributeValue xsi:type="xs:string">test</saml:AttributeValue>
-      </saml:Attribute>
-      <saml:Attribute Name="mail" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:basic">
-        <saml:AttributeValue xsi:type="xs:string">test@example.com</saml:AttributeValue>
-      </saml:Attribute>
-      <saml:Attribute Name="eduPersonAffiliation" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:basic">
-        <saml:AttributeValue xsi:type="xs:string">users</saml:AttributeValue>
-        <saml:AttributeValue xsi:type="xs:string">examplerole1</saml:AttributeValue>
-      </saml:Attribute>
-    </saml:AttributeStatement>
-    <saml:Advice>
-        <dbsc:TrustedCertificate xmlns:dbsc="http://www.w3.org/ns/dbsc/saml"
-            fingerptint="f3e9619a9d701a52701469e4f83d32847b2374e2593f66d48b788647097c234b"
-            fingerprint_alg="SHA_256" />
-    </saml:Advice>
-  </saml:Assertion>
+    <samlp:Status>
+        <samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success" />
+    </samlp:Status>
+    <saml:Assertion
+        xmlns:xs="http://www.w3.org/2001/XMLSchema"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        ID="_d71a3a8e9fcc45c9e9d248ef7049393fc8f04e5f75"
+        IssueInstant="2014-07-17T01:01:48Z"
+        Version="2.0">
+        <saml:Issuer>http://idp.example.com/metadata.php</saml:Issuer>
+        <saml:Subject>
+            <saml:NameID
+                Format="urn:oasis:names:tc:SAML:2.0:nameid-format:transient"
+                SPNameQualifier="http://sp.example.com/demo1/metadata.php">_ce3d2948b4cf20146dee0a0b3dd6f69b6cf86f62d7</saml:NameID>
+            <saml:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
+                <saml:SubjectConfirmationData
+                    InResponseTo="ONELOGIN_4fee3b046395c4e751011e97f8900b5273d56685"
+                    NotOnOrAfter="2024-01-18T06:21:48Z"
+                    Recipient="http://sp.example.com/demo1/index.php?acs" />
+            </saml:SubjectConfirmation>
+        </saml:Subject>
+        <saml:Conditions
+            NotBefore="2014-07-17T01:01:18Z"
+            NotOnOrAfter="2024-01-18T06:21:48Z">
+            <saml:AudienceRestriction>
+                <saml:Audience>http://sp.example.com/demo1/metadata.php</saml:Audience>
+            </saml:AudienceRestriction>
+        </saml:Conditions>
+        <saml:Advice>
+            <dbsc:TrustedCertificate
+                xmlns:dbsc="https://www.w3.org/ns/dbsc/saml"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                fingerprint="f3e9619a9d701a52701469e4f83d32847b2374e2593f66d48b788647097c234b"
+                fingerprint_alg="SHA-256"
+                xsi:schemaLocation="https://www.w3.org/ns/dbsc/saml https://www.w3.org/ns/dbsc/saml/dbsc-saml.xsd" />
+        </saml:Advice>
+        <saml:AuthnStatement
+            AuthnInstant="2014-07-17T01:01:48Z"
+            SessionIndex="_be9967abd904ddcae3c0eb4189adbe3f71e327cf93"
+            SessionNotOnOrAfter="2024-07-17T09:01:48Z">
+            <saml:AuthnContext>
+                <saml:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:Password</saml:AuthnContextClassRef>
+            </saml:AuthnContext>
+        </saml:AuthnStatement>
+        <saml:AttributeStatement>
+            <saml:Attribute
+                Name="uid"
+                NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:basic">
+                <saml:AttributeValue xsi:type="xs:string">test</saml:AttributeValue>
+            </saml:Attribute>
+            <saml:Attribute
+                Name="mail"
+                NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:basic">
+                <saml:AttributeValue xsi:type="xs:string">test@example.com</saml:AttributeValue>
+            </saml:Attribute>
+            <saml:Attribute
+                Name="eduPersonAffiliation"
+                NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:basic">
+                <saml:AttributeValue xsi:type="xs:string">users</saml:AttributeValue>
+                <saml:AttributeValue xsi:type="xs:string">examplerole1</saml:AttributeValue>
+            </saml:Attribute>
+        </saml:AttributeStatement>
+    </saml:Assertion>
 </samlp:Response>


### PR DESCRIPTION
We are restricting the encoding format of key digests and certificates fingerprints using in SAML assertions to [base64url] (https://datatracker.ietf.org/doc/html/rfc4648#section-5) so that it is consistent with the current [DBSC specification](https://w3c.github.io/webappsec-dbsc/#:~:text=The%20RP%20will%20include%20the%20SP%20URL%2C%20session%20identifier%2C%20and%20base64url%2Dencoded%20JWK%20thumbprint%20(see%20%5BRFC4648%5D%20and%20%5BRFC7638%5D)%20in%20the%20%60Secure%2DSession%2DRegistration%60%20header.%20If%20the%20key%20is%20correct%2C%20the%20user%20agent%20will%20create%20a%20session%20on%20the%20RP%20with%20the%20same%20key%20as%20the%20SP.).