### PR TITLE
[Issue 32] Fix up DAPT profiles

### DIFF
--- a/ttml/profile/dapt/extension/Overview.html
+++ b/ttml/profile/dapt/extension/Overview.html
@@ -9,5 +9,13 @@
 
 <p>This namespace is specified at <a href="http://www.w3.org/TR/dapt/">Dubbing and Audio description Profiles of TTML2</a></p>
 
+<p>This is a placeholder for a namespace document that permits dereferencing the Dubbing and Audio description Profiles of TTML2 Extension namespace URI specified at <a href="https://www.w3.org/TR/dapt/">https://www.w3.org/TR/dapt/</a> :</p>
+
+<pre>
+http://www.w3.org/ns/ttml/profile/dapt/extension/
+</pre>
+
+<p>This namespace is stable!</p>
+
   </body>
 </html>

--- a/ttml/profile/dapt1.0/content
+++ b/ttml/profile/dapt1.0/content
@@ -1,15 +1,107 @@
-<!DOCTYPE html>
-<html>
-  <head>
-    <title>Dubbing and Audio description Profiles of TTML2 :: Profile Designator</title>
-  </head>
-
-  <body>
-    <h1>Dubbing and Audio description Profiles of TTML2 :: Profile Designator</h1>
-
-<p><a href="http://www.w3.org/ns/ttml/profile/dapt1.0/content">http://www.w3.org/ns/ttml/profile/dapt1.0/content</a> is the profile designator of the DAPT Content profile of TTML2 specified at <a href="https://www.w3.org/TR/dapt/">https://www.w3.org/TR/dapt/</a></p>
-
-<p>This namespace is stable!</p>
-
-  </body>
-</html>
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This file is the TTML Profile Document representing
+  the DAPT 1.0 Content Profile defined 
+  by DAPT at https://www.w3.org/TR/dapt/ -->
+<profile xmlns="http://www.w3.org/ns/ttml#parameter"
+  designator="http://www.w3.org/ns/ttml/profile/dapt1.0/content"
+  combine="mostRestrictive"
+  type="content">
+  <features xml:base="http://www.w3.org/ns/ttml/feature/">
+    <!-- required (mandatory) feature support -->
+    <feature value="required">#structure</feature>
+    <feature value="required">#timeBase-media</feature>
+    <!-- optional (voluntary) feature support -->
+    <feature value="optional">#animate-fill</feature>
+    <feature value="optional">#animate-minimal</feature>
+    <feature value="optional">#audio</feature>
+    <feature value="optional">#audio-description</feature>
+    <feature value="optional">#audio-speech</feature>
+    <feature value="optional">#bidi</feature>
+    <feature value="optional" extends="#bidi">#bidi-version-2</feature>
+    <feature value="optional">#chunk</feature>
+    <feature value="optional">#content</feature>
+    <feature value="optional">#contentProfiles</feature>
+    <feature value="optional">#contentProfiles-combined</feature>
+    <feature value="optional">#core</feature>
+    <feature value="optional">#data</feature>
+    <feature value="optional">#direction</feature>
+    <feature value="optional">#embedded-audio</feature>
+    <feature value="optional">#embedded-data</feature>
+    <feature value="optional">#frameRate</feature>
+    <feature value="optional">#frameRateMultiplier</feature>
+    <feature value="optional">#gain</feature>
+    <feature value="optional">#metadata</feature>
+    <feature value="optional">#metadata-item</feature>
+    <feature value="optional">#nested-div</feature>
+    <feature value="optional" extends="#metadata">#metadata-version-2</feature>
+    <feature value="optional">#pan</feature>
+    <feature value="optional">#permitFeatureNarrowing</feature>
+    <feature value="optional">#permitFeatureWidening</feature>
+    <feature value="optional">#pitch</feature>
+    <feature value="optional">#presentation-audio</feature>
+    <feature value="optional">#processorProfiles</feature>
+    <feature value="optional">#processorProfiles-combined</feature>
+    <feature value="optional">#resources</feature>
+    <feature value="optional" extends="#animation">#set</feature>
+    <feature value="optional">#set-fill</feature>
+    <feature value="optional">#set-multiple-styles</feature>
+    <feature value="optional">#source</feature>
+    <feature value="optional">#speak</feature>
+    <feature value="optional">#speech</feature>
+    <feature value="optional">#styling</feature>
+    <feature value="optional">#styling-chained</feature>
+    <feature value="optional">#styling-inheritance-content</feature>
+    <feature value="optional">#styling-inline</feature>
+    <feature value="optional">#styling-referential</feature>
+    <feature value="optional">#tickRate</feature>
+    <feature value="optional">#time-clock</feature>
+    <feature value="optional">#time-offset</feature>
+    <feature value="optional">#time-offset-with-frames</feature>
+    <feature value="optional">#time-offset-with-ticks</feature>
+    <feature value="optional">#timing</feature>
+    <feature value="optional">#transformation</feature>
+    <feature value="optional">#unicodeBidi</feature>
+    <feature value="optional">#unicodeBidi-isolate</feature>
+    <feature value="optional" extends="#unicodeBidi">#unicodeBidi-version-2</feature>
+    <feature value="optional">#xlink</feature>
+    <!-- prohibited feature support -->
+    <feature value="prohibited">#animation-out-of-line</feature>
+    <feature value="prohibited">#clockMode</feature>
+    <feature value="prohibited">#clockMode-gps</feature>
+    <feature value="prohibited">#clockMode-local</feature>
+    <feature value="prohibited">#clockMode-utc</feature>
+    <feature value="prohibited">#dropMode</feature>
+    <feature value="prohibited">#dropMode-dropNTSC</feature>
+    <feature value="prohibited">#dropMode-dropPAL</feature>
+    <feature value="prohibited">#dropMode-nonDrop</feature>
+    <feature value="prohibited">#markerMode</feature>
+    <feature value="prohibited">#markerMode-continuous</feature>
+    <feature value="prohibited">#markerMode-discontinuous</feature>
+    <feature value="prohibited">#subFrameRate</feature>
+    <feature value="prohibited">#time-clock-with-frames</feature>
+    <feature value="prohibited">#time-wall-clock</feature>
+    <feature value="prohibited">#timeBase-clock</feature>
+    <feature value="prohibited">#timeBase-smpte</feature>
+    <feature value="prohibited">#timeContainer</feature>
+  </features>
+  <extensions xml:base="http://www.w3.org/ns/ttml/profile/dapt/extension/">
+    <!-- required (mandatory) extension support -->
+    <extension value="required">#contentProfiles-root</extension>
+    <extension value="required">#represents</extension>
+    <extension value="required">#scriptRepresents-root</extension>
+    <extension value="required">#scriptType-root</extension>
+    <extension value="required">#serialization</extension>
+    <extension value="required">#xmlLang-root</extension>
+    <!-- optional (voluntary) extension support -->
+    <extension value="optional">#agent</extension>
+    <extension value="optional">#daptOriginTimecode</extension>
+    <extension value="optional">#descType</extension>
+    <extension value="optional">#onScreen</extension>
+    <extension value="optional">#scriptEventMapping</extension>
+    <extension value="optional">#textLanguageSource</extension>
+    <!-- prohibited extension support -->
+    <extension value="prohibited">#profile-root</extension>
+    <extension value="prohibited">#source-data</extension>
+    <extension value="prohibited">#xmlLang-audio-nonMatching</extension>
+</extensions>
+</profile>

--- a/ttml/profile/dapt1.0/processor
+++ b/ttml/profile/dapt1.0/processor
@@ -1,15 +1,105 @@
-<!DOCTYPE html>
-<html>
-  <head>
-    <title>Dubbing and Audio description Profiles of TTML2 :: Profile Designator</title>
-  </head>
-
-  <body>
-    <h1>Dubbing and Audio description Profiles of TTML2 :: Profile Designator</h1>
-
-<p><a href="http://www.w3.org/ns/ttml/profile/dapt1.0/processor">http://www.w3.org/ns/ttml/profile/dapt1.0/processor</a> is the profile designator of the DAPT Processor profile of TTML2 specified at <a href="https://www.w3.org/TR/dapt/">https://www.w3.org/TR/dapt/</a></p>
-
-<p>This namespace is stable!</p>
-
-  </body>
-</html>
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This file is the TTML Profile Document representing
+  the DAPT 1.0 Processor Profile defined 
+  by DAPT at https://www.w3.org/TR/dapt/ -->
+<profile xmlns="http://www.w3.org/ns/ttml#parameter"
+  designator="http://www.w3.org/ns/ttml/profile/dapt1.0/processor"
+  combine="mostRestrictive"
+  type="processor">
+  <features xml:base="http://www.w3.org/ns/ttml/feature/">
+    <!-- required (mandatory) feature support -->
+    <feature value="required">#animate-fill</feature>
+    <feature value="required">#animate-minimal</feature>
+    <feature value="required">#audio</feature>
+    <feature value="required">#audio-description</feature>
+    <feature value="required">#audio-speech</feature>
+    <feature value="required">#bidi</feature>
+    <feature value="required" extends="#bidi">#bidi-version-2</feature>
+    <feature value="required">#chunk</feature>
+    <feature value="required">#content</feature>
+    <feature value="required">#contentProfiles</feature>
+    <feature value="required">#core</feature>
+    <feature value="required">#data</feature>
+    <feature value="required">#direction</feature>
+    <feature value="required">#embedded-audio</feature>
+    <feature value="required">#embedded-data</feature>
+    <feature value="required">#frameRate</feature>
+    <feature value="required">#frameRateMultiplier</feature>
+    <feature value="required">#gain</feature>
+    <feature value="required">#metadata</feature>
+    <feature value="required">#metadata-item</feature>
+    <feature value="required">#nested-div</feature>
+    <feature value="required" extends="#metadata">#metadata-version-2</feature>
+    <feature value="required">#pan</feature>
+    <feature value="required">#pitch</feature>
+    <feature value="required">#presentation-audio</feature>
+    <feature value="required">#resources</feature>
+    <feature value="required" extends="#animation">#set</feature>
+    <feature value="required">#set-fill</feature>
+    <feature value="required">#set-multiple-styles</feature>
+    <feature value="required">#source</feature>
+    <feature value="required">#speak</feature>
+    <feature value="required">#speech</feature>
+    <feature value="required">#structure</feature>
+    <feature value="required">#styling</feature>
+    <feature value="required">#styling-chained</feature>
+    <feature value="required">#styling-inheritance-content</feature>
+    <feature value="required">#styling-inline</feature>
+    <feature value="required">#styling-referential</feature>
+    <feature value="required">#tickRate</feature>
+    <feature value="required">#time-clock</feature>
+    <feature value="required">#time-offset</feature>
+    <feature value="required">#time-offset-with-frames</feature>
+    <feature value="required">#time-offset-with-ticks</feature>
+    <feature value="required">#timeBase-media</feature>
+    <feature value="required">#timing</feature>
+    <feature value="required">#transformation</feature>
+    <feature value="required">#unicodeBidi</feature>
+    <feature value="required">#unicodeBidi-isolate</feature>
+    <feature value="required" extends="#unicodeBidi">#unicodeBidi-version-2</feature>
+    <feature value="required">#xlink</feature>
+    <!-- optional (voluntary) feature support -->
+    <feature value="optional">#animation-out-of-line</feature>
+    <feature value="optional">#clockMode</feature>
+    <feature value="optional">#clockMode-gps</feature>
+    <feature value="optional">#clockMode-local</feature>
+    <feature value="optional">#clockMode-utc</feature>
+    <feature value="optional">#contentProfiles-combined</feature>
+    <feature value="optional">#dropMode</feature>
+    <feature value="optional">#dropMode-dropNTSC</feature>
+    <feature value="optional">#dropMode-dropPAL</feature>
+    <feature value="optional">#dropMode-nonDrop</feature>
+    <feature value="optional">#markerMode</feature>
+    <feature value="optional">#markerMode-continuous</feature>
+    <feature value="optional">#markerMode-discontinuous</feature>
+    <feature value="optional">#permitFeatureNarrowing</feature>
+    <feature value="optional">#permitFeatureWidening</feature>
+    <feature value="optional">#processorProfiles</feature>
+    <feature value="optional">#processorProfiles-combined</feature>
+    <feature value="optional">#subFrameRate</feature>
+    <feature value="optional">#time-clock-with-frames</feature>
+    <feature value="optional">#time-wall-clock</feature>
+    <feature value="optional">#timeBase-clock</feature>
+    <feature value="optional">#timeBase-smpte</feature>
+    <feature value="optional">#timeContainer</feature>
+  </features>
+  <extensions xml:base="http://www.w3.org/ns/ttml/profile/dapt/extension/">
+    <!-- required (mandatory) extension support -->
+    <extension value="required">#agent</extension>
+    <extension value="required">#contentProfiles-root</extension>
+    <extension value="required">#daptOriginTimecode</extension>
+    <extension value="required">#descType</extension>
+    <extension value="required">#onScreen</extension>
+    <extension value="required">#represents</extension>
+    <extension value="required">#scriptRepresents-root</extension>
+    <extension value="required">#scriptType-root</extension>
+    <extension value="required">#serialization</extension>
+    <extension value="required">#textLanguageSource</extension>
+    <extension value="required">#xmlLang-root</extension>
+    <!-- optional (voluntary) extension support -->
+    <extension value="optional">#profile-root</extension>
+    <extension value="optional">#scriptEventMapping</extension>
+    <extension value="optional">#source-data</extension>
+    <extension value="optional">#xmlLang-audio-nonMatching</extension>
+</extensions>
+</profile>


### PR DESCRIPTION
Fix #32 by replacing the content at the URIs of the DAPT 1.0 Content Profile and DAPT 1.0 Processor Profile with copies of the actual profile documents. They are XML documents that include a comment at the top that points to the specification URL in which they are defined.

Also in passing fix up the DAPT extension namespace Overview.html to include its own URI and a statement of stability.