### PR TITLE
shex: add shape-map and ShapeDecl terms, regenerate from source

### DIFF
--- a/shex.html
+++ b/shex.html
@@ -22,15 +22,15 @@ var respecConfig = {
     },
     specStatus:       "base",
     shortName:        "shexns",
-    publishDate:      "2017-07-07",
+    publishDate:      "2026-08-06",
     thisVersion:      "https://www.w3.org/ns/shex",
-    edDraftURI:       "https://shexspec.github.io/ns/shex.html",
+    edDraftURI:       "https://github.com/shexSpec/shexTest/tree/main/vocab",
     // lcEnd: "3000-01-01",
     // crEnd: "3000-01-01",
     testSuiteURI:     "https://shexspec.github.io/shexTest/",
     includePermalinks:true,
     noRecTrack:       true,
-    github:           "https://github.com/shexspec/shexspec.github.io",
+    github:           "https://github.com/shexSpec/shexTest",
     editors: [{
       name:       "Gregg Kellogg",
       url:        "http://greggkellogg.net/",
@@ -83,11 +83,12 @@ var respecConfig = {
         <!--These versions may also be retrieved from <code>FIXME</code> using an appropiate HTTP <em>Accept</em> header.-->
       </p>
       <dl>
-        <dt>Published:</dt><dd><time property="dc:date">2017-07-07</time></dd>
+        <dt>Published:</dt><dd><time property="dc:date">2026-08-06</time></dd>
         <dt>Version Info:</dt>
-        <dd><a href="https://github.com/shexSpec/shexspec.github.io/commit/e05f8e97471f5271f50612bed253102f770364b4" property="owl:versionInfo">https://github.com/shexSpec/shexspec.github.io/commit/e05f8e97471f5271f50612bed253102f770364b4</a></dd>
+        <dd><a href="https://github.com/shexSpec/shexTest/commit/e51237875c69bb1fbc86def8f3c895b213a6ff9c" property="owl:versionInfo">https://github.com/shexSpec/shexTest/commit/e51237875c69bb1fbc86def8f3c895b213a6ff9c</a></dd>
         <dt>See Also:</dt>
           <dd><a href="http://shex.io/shex-semantics" property="rdfs:seeAlso">http://shex.io/shex-semantics</a></dd>
+          <dd><a href="https://shexspec.github.io/shape-map/" property="rdfs:seeAlso">https://shexspec.github.io/shape-map/</a></dd>
       </dl>
     </section>
     <section id="sotd">
@@ -258,6 +259,15 @@ var respecConfig = {
               </dl>
           </td>
         </tr>
+        <tr id="QueryMap">
+          <td class="bold">QueryMap</td>
+          <td resource="shex:QueryMap" typeof="rdfs:Class">
+            <em property="rdfs:label">Query Map</em>
+            <span class="permalink"><a href="#QueryMap" aria-label="Permalink for Query Map" title="Permalink for Query Map"><span>§</span></a></span>
+            <p property="rdfs:comment">A map of node selectors to shape labels, used to select the nodes to be validated against particular shapes. Node selectors are RDF nodes or triple patterns.</p>
+            <span property="rdfs:isDefinedBy" resource="shex:"></span>
+          </td>
+        </tr>
         <tr id="Schema">
           <td class="bold">Schema</td>
           <td resource="shex:Schema" typeof="rdfs:Class">
@@ -302,6 +312,15 @@ var respecConfig = {
               </dl>
           </td>
         </tr>
+        <tr id="ShapeDecl">
+          <td class="bold">ShapeDecl</td>
+          <td resource="shex:ShapeDecl" typeof="rdfs:Class">
+            <em property="rdfs:label">Shape Declaration</em>
+            <span class="permalink"><a href="#ShapeDecl" aria-label="Permalink for Shape Declaration" title="Permalink for Shape Declaration"><span>§</span></a></span>
+            <p property="rdfs:comment">Associates a shape expression with a label, and optionally declares it abstract. The shapes in a Schema are ShapeDecls.</p>
+            <span property="rdfs:isDefinedBy" resource="shex:"></span>
+          </td>
+        </tr>
         <tr id="ShapeExpression">
           <td class="bold">ShapeExpression</td>
           <td resource="shex:ShapeExpression" typeof="rdfs:Class">
@@ -321,6 +340,19 @@ var respecConfig = {
               <dl class="terms">
                   <dt>rdfs:subClassOf</dt>
                       <dd property="rdfs:subClassOf" resource="shex:ShapeExpression">shex:ShapeExpression</dd>
+              </dl>
+          </td>
+        </tr>
+        <tr id="ShapeMap">
+          <td class="bold">ShapeMap</td>
+          <td resource="shex:ShapeMap" typeof="rdfs:Class">
+            <em property="rdfs:label">Shape Map</em>
+            <span class="permalink"><a href="#ShapeMap" aria-label="Permalink for Shape Map" title="Permalink for Shape Map"><span>§</span></a></span>
+            <p property="rdfs:comment">A QueryMap in which each node selector is an RDF node; associates RDF nodes with shapes, optionally recording the validation status of each association.</p>
+            <span property="rdfs:isDefinedBy" resource="shex:"></span>
+              <dl class="terms">
+                  <dt>rdfs:subClassOf</dt>
+                      <dd property="rdfs:subClassOf" resource="shex:QueryMap">shex:QueryMap</dd>
               </dl>
           </td>
         </tr>
@@ -405,6 +437,21 @@ var respecConfig = {
       <h2>Property Definitions</h2>
       <p>The following are property definitions in the <code>shex</code> namespace:</p>
       <table class="rdfs-definition">
+        <tr id="abstract">
+          <td class="bold">abstract</td>
+          <td resource="shex:abstract" typeof="rdf:Property">
+            <em property="rdfs:label">abstract</em>
+            <span class="permalink"><a href="#abstract" aria-label="Permalink for abstract" title="Permalink for abstract"><span>§</span></a></span>
+            <p property="rdfs:comment">Declares a ShapeDecl abstract, meaning that every reference to it must also identify at least one non-abstract shape.</p>
+            <span property="rdfs:isDefinedBy" resource="shex:"></span>
+              <dl class="terms">
+                  <dt>rdfs:range</dt>
+                      <dd property="rdfs:range" resource="xsd:boolean">xsd:boolean</dd>
+                  <dt>rdfs:domain</dt>
+                      <dd property="rdfs:domain" resource="shex:ShapeDecl">shex:ShapeDecl</dd>
+              </dl>
+          </td>
+        </tr>
         <tr id="annotation">
           <td class="bold">annotation</td>
           <td resource="shex:annotation" typeof="rdf:Property">
@@ -523,6 +570,21 @@ var respecConfig = {
               </dl>
           </td>
         </tr>
+        <tr id="extends">
+          <td class="bold">extends</td>
+          <td resource="shex:extends" typeof="rdf:Property">
+            <em property="rdfs:label">extends</em>
+            <span class="permalink"><a href="#extends" aria-label="Permalink for extends" title="Permalink for extends"><span>§</span></a></span>
+            <p property="rdfs:comment">Base shape expressions for this shape.</p>
+            <span property="rdfs:isDefinedBy" resource="shex:"></span>
+              <dl class="terms">
+                  <dt>rdfs:range</dt>
+                      <dd property="rdfs:range" resource="shex:ShapeExpression">shex:ShapeExpression</dd>
+                  <dt>rdfs:domain</dt>
+                      <dd property="rdfs:domain" resource="shex:Shape">shex:Shape</dd>
+              </dl>
+          </td>
+        </tr>
         <tr id="extra">
           <td class="bold">extra</td>
           <td resource="shex:extra" typeof="rdf:Property">
@@ -535,21 +597,6 @@ var respecConfig = {
                       <dd property="rdfs:range" resource="rdfs:Resource">rdfs:Resource</dd>
                   <dt>rdfs:domain</dt>
                       <dd property="rdfs:domain" resource="shex:Shape">shex:Shape</dd>
-              </dl>
-          </td>
-        </tr>
-        <tr id="extends">
-          <td class="bold">extends</td>
-          <td resource="shex:extends" typeof="rdf:property">
-            <em property="rdfs:label">extends</em>
-            <span class="permalink"><a href="#extends" aria-label="permalink for extends" title="permalink for extends"><span>§</span></a></span>
-            <p property="rdfs:comment">Base shape expressions for this shape.</p>
-            <span property="rdfs:isdefinedby" resource="shex:"></span>
-              <dl class="terms">
-                  <dt>rdfs:range</dt>
-                      <dd property="rdfs:range" resource="rdfs:resource">rdfs:resource</dd>
-                  <dt>rdfs:domain</dt>
-                      <dd property="rdfs:domain" resource="shex:shape">shex:shape</dd>
               </dl>
           </td>
         </tr>
@@ -582,6 +629,21 @@ var respecConfig = {
                       <dd property="rdfs:range" resource="xsd:integer">xsd:integer</dd>
                   <dt>rdfs:domain</dt>
                       <dd property="rdfs:domain" resource="shex:NodeConstraint">shex:NodeConstraint</dd>
+              </dl>
+          </td>
+        </tr>
+        <tr id="imports">
+          <td class="bold">imports</td>
+          <td resource="shex:imports" typeof="rdf:Property">
+            <em property="rdfs:label">imports</em>
+            <span class="permalink"><a href="#imports" aria-label="Permalink for imports" title="Permalink for imports"><span>§</span></a></span>
+            <p property="rdfs:comment">Schemas imported by this Schema; their shape and triple expression labels are also in scope here.</p>
+            <span property="rdfs:isDefinedBy" resource="shex:"></span>
+              <dl class="terms">
+                  <dt>rdfs:range</dt>
+                      <dd property="rdfs:range" resource="rdfs:Resource">rdfs:Resource</dd>
+                  <dt>rdfs:domain</dt>
+                      <dd property="rdfs:domain" resource="shex:Schema">shex:Schema</dd>
               </dl>
           </td>
         </tr>
@@ -809,6 +871,21 @@ var respecConfig = {
               </dl>
           </td>
         </tr>
+        <tr id="node">
+          <td class="bold">node</td>
+          <td resource="shex:node" typeof="rdf:Property">
+            <em property="rdfs:label">node</em>
+            <span class="permalink"><a href="#node" aria-label="Permalink for node" title="Permalink for node"><span>§</span></a></span>
+            <p property="rdfs:comment">An RDF node, or a triple pattern which is used to select RDF nodes to be validated.</p>
+            <span property="rdfs:isDefinedBy" resource="shex:"></span>
+              <dl class="terms">
+                  <dt>rdfs:range</dt>
+                      <dd property="rdfs:range" resource="rdfs:Resource">rdfs:Resource</dd>
+                  <dt>rdfs:domain</dt>
+                      <dd property="rdfs:domain" resource="shex:QueryMap">shex:QueryMap</dd>
+              </dl>
+          </td>
+        </tr>
         <tr id="nodeKind">
           <td class="bold">nodeKind</td>
           <td resource="shex:nodeKind" typeof="rdf:Property">
@@ -908,18 +985,37 @@ var respecConfig = {
               </dl>
           </td>
         </tr>
-        <tr id="shapeExpr">
-          <td class="bold">shapeExpr</td>
-          <td resource="shex:shapeExpr" typeof="rdf:Property">
-            <em property="rdfs:label">shape expression</em>
-            <span class="permalink"><a href="#shapeExpr" aria-label="Permalink for shape expression" title="Permalink for shape expression"><span>§</span></a></span>
-            <p property="rdfs:comment">Shape Expression referenced by this shape.</p>
+        <tr id="shape">
+          <td class="bold">shape</td>
+          <td resource="shex:shape" typeof="rdf:Property">
+            <em property="rdfs:label">shape</em>
+            <span class="permalink"><a href="#shape" aria-label="Permalink for shape" title="Permalink for shape"><span>§</span></a></span>
+            <p property="rdfs:comment">A ShEx shape expression label identifying the shape expression against which the selected nodes are validated, or the string "START" for the schema's start shape expression.</p>
             <span property="rdfs:isDefinedBy" resource="shex:"></span>
               <dl class="terms">
                   <dt>rdfs:range</dt>
                       <dd property="rdfs:range" resource="shex:ShapeExpression">shex:ShapeExpression</dd>
                   <dt>rdfs:domain</dt>
-                      <dd property="rdfs:domain" resource="shex:ShapeNot">shex:ShapeNot</dd>
+                      <dd property="rdfs:domain" resource="shex:QueryMap">shex:QueryMap</dd>
+              </dl>
+          </td>
+        </tr>
+        <tr id="shapeExpr">
+          <td class="bold">shapeExpr</td>
+          <td resource="shex:shapeExpr" typeof="rdf:Property">
+            <em property="rdfs:label">shape expression</em>
+            <span class="permalink"><a href="#shapeExpr" aria-label="Permalink for shape expression" title="Permalink for shape expression"><span>§</span></a></span>
+            <p property="rdfs:comment">Shape Expression referenced by this shape or shape declaration.</p>
+            <span property="rdfs:isDefinedBy" resource="shex:"></span>
+              <dl class="terms">
+                  <dt>rdfs:range</dt>
+                      <dd property="rdfs:range" resource="shex:ShapeExpression">shex:ShapeExpression</dd>
+                  <dt>rdfs:domain</dt>
+                      <dd property="rdfs:domain" resource="_:">
+                        Union of
+                        <span property="owl:unionOf" inlist=true resource="shex:ShapeNot">shex:ShapeNot</span>
+                        <span property="owl:unionOf" inlist=true resource="shex:ShapeDecl">shex:ShapeDecl</span>
+                      </dd>
               </dl>
           </td>
         </tr>
@@ -949,11 +1045,11 @@ var respecConfig = {
           <td resource="shex:shapes" typeof="rdf:Property">
             <em property="rdfs:label">shapes</em>
             <span class="permalink"><a href="#shapes" aria-label="Permalink for shapes" title="Permalink for shapes"><span>§</span></a></span>
-            <p property="rdfs:comment">Shapes in this Schema.</p>
+            <p property="rdfs:comment">Shape declarations in this Schema.</p>
             <span property="rdfs:isDefinedBy" resource="shex:"></span>
               <dl class="terms">
                   <dt>rdfs:range</dt>
-                      <dd property="rdfs:range" resource="shex:ShapeExpression">shex:ShapeExpression</dd>
+                      <dd property="rdfs:range" resource="shex:ShapeDecl">shex:ShapeDecl</dd>
                   <dt>rdfs:domain</dt>
                       <dd property="rdfs:domain" resource="shex:Schema">shex:Schema</dd>
               </dl>
@@ -986,6 +1082,21 @@ var respecConfig = {
                       <dd property="rdfs:range" resource="shex:SemAct">shex:SemAct</dd>
                   <dt>rdfs:domain</dt>
                       <dd property="rdfs:domain" resource="shex:Schema">shex:Schema</dd>
+              </dl>
+          </td>
+        </tr>
+        <tr id="status">
+          <td class="bold">status</td>
+          <td resource="shex:status" typeof="rdf:Property">
+            <em property="rdfs:label">status</em>
+            <span class="permalink"><a href="#status" aria-label="Permalink for status" title="Permalink for status"><span>§</span></a></span>
+            <p property="rdfs:comment">The validation status of a node/shape association: "conformant" or "nonconformant". Defaults to "conformant".</p>
+            <span property="rdfs:isDefinedBy" resource="shex:"></span>
+              <dl class="terms">
+                  <dt>rdfs:range</dt>
+                      <dd property="rdfs:range" resource="xsd:string">xsd:string</dd>
+                  <dt>rdfs:domain</dt>
+                      <dd property="rdfs:domain" resource="shex:ShapeMap">shex:ShapeMap</dd>
               </dl>
           </td>
         </tr>
@@ -1103,6 +1214,24 @@ var respecConfig = {
       <h2>Instance Definitions</h2>
       <p>The following are instance definitions in the <code>shex</code> namespace:</p>
       <table class="rdfs-definition">
+        <tr id="FOCUS">
+          <td class="bold">FOCUS</td>
+          <td resource="shex:FOCUS" typeof="rdfs:Resource">
+            <em property="rdfs:label">FOCUS</em>
+            <span class="permalink"><a href="#FOCUS" aria-label="Permalink for FOCUS" title="Permalink for FOCUS"><span>§</span></a></span>
+            <p property="rdfs:comment">In a triple pattern used as a node selector, indicates the position (subject or object) of the nodes to be selected. A triple pattern has exactly one focus selector.</p>
+            <span property="rdfs:isDefinedBy" resource="shex:"></span>
+          </td>
+        </tr>
+        <tr id="_">
+          <td class="bold">_</td>
+          <td resource="shex:_" typeof="rdfs:Resource">
+            <em property="rdfs:label">wildcard</em>
+            <span class="permalink"><a href="#_" aria-label="Permalink for wildcard" title="Permalink for wildcard"><span>§</span></a></span>
+            <p property="rdfs:comment">In a triple pattern used as a node selector, a wildcard indicating that the position (subject or object) may hold any value.</p>
+            <span property="rdfs:isDefinedBy" resource="shex:"></span>
+          </td>
+        </tr>
         <tr id="bnode">
           <td class="bold">bnode</td>
           <td resource="shex:bnode" typeof="NodeKind">
@@ -1152,6 +1281,10 @@ var respecConfig = {
         <dd>
             shex:EachOf
         </dd>
+        <dt>FOCUS</dt>
+        <dd>
+            shex:FOCUS
+        </dd>
         <dt>IriStem</dt>
         <dd>
             shex:IriStem
@@ -1188,6 +1321,10 @@ var respecConfig = {
         <dd>
             shex:OneOf
         </dd>
+        <dt>QueryMap</dt>
+        <dd>
+            shex:QueryMap
+        </dd>
         <dt>Schema</dt>
         <dd>
             shex:Schema
@@ -1204,9 +1341,17 @@ var respecConfig = {
         <dd>
             shex:ShapeAnd
         </dd>
+        <dt>ShapeDecl</dt>
+        <dd>
+            shex:ShapeDecl
+        </dd>
         <dt>ShapeExternal</dt>
         <dd>
             shex:ShapeExternal
+        </dd>
+        <dt>ShapeMap</dt>
+        <dd>
+            shex:ShapeMap
         </dd>
         <dt>ShapeNot</dt>
         <dd>
@@ -1231,6 +1376,15 @@ var respecConfig = {
         <dt>Wildcard</dt>
         <dd>
             shex:Wildcard
+        </dd>
+        <dt>_</dt>
+        <dd>
+            shex:_
+        </dd>
+        <dt>abstract</dt>
+        <dd>
+            shex:abstract
+            with string values interpreted as xsd:boolean
         </dd>
         <dt>annotations</dt>
         <dd>
@@ -1273,14 +1427,14 @@ var respecConfig = {
             with string values interpreted as @id
               with array values interpreted as @list
         </dd>
-        <dt>extra</dt>
-        <dd>
-            shex:extra
-            with string values interpreted as @id
-        </dd>
         <dt>extends</dt>
         <dd>
             shex:extends
+            with string values interpreted as @id
+        </dd>
+        <dt>extra</dt>
+        <dd>
+            shex:extra
             with string values interpreted as @id
         </dd>
         <dt>flags</dt>
@@ -1295,6 +1449,12 @@ var respecConfig = {
         <dt>id</dt>
         <dd>
             @id
+        </dd>
+        <dt>imports</dt>
+        <dd>
+            shex:imports
+            with string values interpreted as @id
+              with array values interpreted as @list
         </dd>
         <dt>inverse</dt>
         <dd>
@@ -1367,6 +1527,11 @@ var respecConfig = {
             shex:name
             with string values interpreted as @id
         </dd>
+        <dt>node</dt>
+        <dd>
+            shex:node
+            with string values interpreted as @id
+        </dd>
         <dt>nodeKind</dt>
         <dd>
             shex:nodeKind
@@ -1404,6 +1569,11 @@ var respecConfig = {
             with string values interpreted as @id
               with array values interpreted as @list
         </dd>
+        <dt>shape</dt>
+        <dd>
+            shex:shape
+            with string values interpreted as @id
+        </dd>
         <dt>shapeExpr</dt>
         <dd>
             shex:shapeExpr
@@ -1419,6 +1589,7 @@ var respecConfig = {
         <dd>
             shex:shapes
             with string values interpreted as @id
+              with array values interpreted as @list
         </dd>
         <dt>shex</dt>
         <dd>
@@ -1434,6 +1605,10 @@ var respecConfig = {
             shex:startActs
             with string values interpreted as @id
               with array values interpreted as @list
+        </dd>
+        <dt>status</dt>
+        <dd>
+            shex:status
         </dd>
         <dt>stem</dt>
         <dd>

--- a/shex.jsonld
+++ b/shex.jsonld
@@ -29,17 +29,24 @@
     "LiteralStemRange": "shex:LiteralStemRange",
     "NodeConstraint": "shex:NodeConstraint",
     "OneOf": "shex:OneOf",
+    "QueryMap": "shex:QueryMap",
     "Schema": "shex:Schema",
     "SemAct": "shex:SemAct",
     "Shape": "shex:Shape",
     "ShapeAnd": "shex:ShapeAnd",
+    "ShapeDecl": "shex:ShapeDecl",
     "ShapeExternal": "shex:ShapeExternal",
+    "ShapeMap": "shex:ShapeMap",
     "ShapeNot": "shex:ShapeNot",
     "ShapeOr": "shex:ShapeOr",
     "Stem": "shex:Stem",
     "StemRange": "shex:StemRange",
     "TripleConstraint": "shex:TripleConstraint",
     "Wildcard": "shex:Wildcard",
+    "abstract": {
+      "@id": "shex:abstract",
+      "@type": "xsd:boolean"
+    },
     "closed": {
       "@id": "shex:closed",
       "@type": "xsd:boolean"
@@ -61,12 +68,12 @@
       "@type": "@id",
       "@container": "@list"
     },
-    "extra": {
-      "@id": "shex:extra",
-      "@type": "@id"
-    },
     "extends": {
       "@id": "shex:extends",
+      "@type": "@id"
+    },
+    "extra": {
+      "@id": "shex:extra",
       "@type": "@id"
     },
     "flags": {
@@ -76,6 +83,11 @@
     "fractiondigits": {
       "@id": "shex:fractiondigits",
       "@type": "xsd:integer"
+    },
+    "imports": {
+      "@id": "shex:imports",
+      "@type": "@id",
+      "@container": "@list"
     },
     "inverse": {
       "@id": "shex:inverse",
@@ -125,6 +137,10 @@
       "@id": "shex:name",
       "@type": "@id"
     },
+    "node": {
+      "@id": "shex:node",
+      "@type": "@id"
+    },
     "nodeKind": {
       "@id": "shex:nodeKind",
       "@type": "@vocab"
@@ -145,6 +161,10 @@
       "@id": "shex:semActs",
       "@type": "@id",
       "@container": "@list"
+    },
+    "shape": {
+      "@id": "shex:shape",
+      "@type": "@id"
     },
     "shapeExpr": {
       "@id": "shex:shapeExpr",
@@ -169,6 +189,10 @@
       "@type": "@id",
       "@container": "@list"
     },
+    "status": {
+      "@id": "shex:status",
+      "@language": null
+    },
     "stem": {
       "@id": "shex:stem",
       "@type": "xsd:string"
@@ -186,6 +210,8 @@
       "@type": "@id",
       "@container": "@list"
     },
+    "FOCUS": "shex:FOCUS",
+    "_": "shex:_",
     "bnode": "shex:bnode",
     "iri": "shex:iri",
     "literal": "shex:literal",
@@ -277,10 +303,11 @@
     "dc:description": {
       "en": "This document describes the RDFS vocabulary description used in the Shape Expression Language (ShEx) [[shex-semantics]] along with the default JSON-LD Context and shape expression to validate RDF versions of shapes."
     },
-    "dc:date": "2017-07-07",
-    "owl:versionInfo": "https://github.com/shexSpec/shexspec.github.io/commit/e05f8e97471f5271f50612bed253102f770364b4",
+    "dc:date": "2026-08-06",
+    "owl:versionInfo": "https://github.com/shexSpec/shexTest/commit/e51237875c69bb1fbc86def8f3c895b213a6ff9c",
     "rdfs:seeAlso": [
-      "http://shex.io/shex-semantics"
+      "http://shex.io/shex-semantics",
+      "https://shexspec.github.io/shape-map/"
     ],
     "rdfs_classes": [
       {
@@ -413,6 +440,16 @@
         "rdfs:subClassOf": "shex:TripleExpression"
       },
       {
+        "@id": "shex:QueryMap",
+        "@type": "rdfs:Class",
+        "rdfs:label": {
+          "en": "Query Map"
+        },
+        "rdfs:comment": {
+          "en": "A map of node selectors to shape labels, used to select the nodes to be validated against particular shapes. Node selectors are RDF nodes or triple patterns."
+        }
+      },
+      {
         "@id": "shex:Schema",
         "@type": "rdfs:Class",
         "rdfs:label": {
@@ -455,6 +492,16 @@
         "rdfs:subClassOf": "shex:ShapeExpression"
       },
       {
+        "@id": "shex:ShapeDecl",
+        "@type": "rdfs:Class",
+        "rdfs:label": {
+          "en": "Shape Declaration"
+        },
+        "rdfs:comment": {
+          "en": "Associates a shape expression with a label, and optionally declares it abstract. The shapes in a Schema are ShapeDecls."
+        }
+      },
+      {
         "@id": "shex:ShapeExpression",
         "@type": "rdfs:Class",
         "rdfs:label": {
@@ -474,6 +521,17 @@
           "en": "A reference to a shape defined in some external Schema."
         },
         "rdfs:subClassOf": "shex:ShapeExpression"
+      },
+      {
+        "@id": "shex:ShapeMap",
+        "@type": "rdfs:Class",
+        "rdfs:label": {
+          "en": "Shape Map"
+        },
+        "rdfs:comment": {
+          "en": "A QueryMap in which each node selector is an RDF node; associates RDF nodes with shapes, optionally recording the validation status of each association."
+        },
+        "rdfs:subClassOf": "shex:QueryMap"
       },
       {
         "@id": "shex:ShapeNot",
@@ -550,6 +608,18 @@
       }
     ],
     "rdfs_properties": [
+      {
+        "@id": "shex:abstract",
+        "@type": "rdf:Property",
+        "rdfs:label": {
+          "en": "abstract"
+        },
+        "rdfs:comment": {
+          "en": "Declares a ShapeDecl abstract, meaning that every reference to it must also identify at least one non-abstract shape."
+        },
+        "rdfs:domain": "shex:ShapeDecl",
+        "rdfs:range": "xsd:boolean"
+      },
       {
         "@id": "shex:annotation",
         "@type": "rdf:Property",
@@ -651,18 +721,6 @@
         "rdfs:range": "shex:TripleExpression"
       },
       {
-        "@id": "shex:extra",
-        "@type": "rdf:Property",
-        "rdfs:label": {
-          "en": "extra"
-        },
-        "rdfs:comment": {
-          "en": "Properties which may have extra values beyond those matched through a constraint."
-        },
-        "rdfs:domain": "shex:Shape",
-        "rdfs:range": "rdfs:Resource"
-      },
-      {
         "@id": "shex:extends",
         "@type": "rdf:Property",
         "rdfs:label": {
@@ -673,6 +731,18 @@
         },
         "rdfs:domain": "shex:Shape",
         "rdfs:range": "shex:ShapeExpression"
+      },
+      {
+        "@id": "shex:extra",
+        "@type": "rdf:Property",
+        "rdfs:label": {
+          "en": "extra"
+        },
+        "rdfs:comment": {
+          "en": "Properties which may have extra values beyond those matched through a constraint."
+        },
+        "rdfs:domain": "shex:Shape",
+        "rdfs:range": "rdfs:Resource"
       },
       {
         "@id": "shex:flags",
@@ -698,6 +768,18 @@
         "rdfs:subPropertyOf": "shex:numericFacet",
         "rdfs:domain": "shex:NodeConstraint",
         "rdfs:range": "xsd:integer"
+      },
+      {
+        "@id": "shex:imports",
+        "@type": "rdf:Property",
+        "rdfs:label": {
+          "en": "imports"
+        },
+        "rdfs:comment": {
+          "en": "Schemas imported by this Schema; their shape and triple expression labels are also in scope here."
+        },
+        "rdfs:domain": "shex:Schema",
+        "rdfs:range": "rdfs:Resource"
       },
       {
         "@id": "shex:inverse",
@@ -887,6 +969,18 @@
         "rdfs:range": "rdfs:Resource"
       },
       {
+        "@id": "shex:node",
+        "@type": "rdf:Property",
+        "rdfs:label": {
+          "en": "node"
+        },
+        "rdfs:comment": {
+          "en": "An RDF node, or a triple pattern which is used to select RDF nodes to be validated."
+        },
+        "rdfs:domain": "shex:QueryMap",
+        "rdfs:range": "rdfs:Resource"
+      },
+      {
         "@id": "shex:nodeKind",
         "@type": "rdf:Property",
         "rdfs:label": {
@@ -970,15 +1064,32 @@
         "rdfs:range": "shex:SemAct"
       },
       {
+        "@id": "shex:shape",
+        "@type": "rdf:Property",
+        "rdfs:label": {
+          "en": "shape"
+        },
+        "rdfs:comment": {
+          "en": "A ShEx shape expression label identifying the shape expression against which the selected nodes are validated, or the string \"START\" for the schema's start shape expression."
+        },
+        "rdfs:domain": "shex:QueryMap",
+        "rdfs:range": "shex:ShapeExpression"
+      },
+      {
         "@id": "shex:shapeExpr",
         "@type": "rdf:Property",
         "rdfs:label": {
           "en": "shape expression"
         },
         "rdfs:comment": {
-          "en": "Shape Expression referenced by this shape."
+          "en": "Shape Expression referenced by this shape or shape declaration."
         },
-        "rdfs:domain": "shex:ShapeNot",
+        "rdfs:domain": {
+          "owl:unionOf": [
+            "shex:ShapeNot",
+            "shex:ShapeDecl"
+          ]
+        },
         "rdfs:range": "shex:ShapeExpression"
       },
       {
@@ -1006,10 +1117,10 @@
           "en": "shapes"
         },
         "rdfs:comment": {
-          "en": "Shapes in this Schema."
+          "en": "Shape declarations in this Schema."
         },
         "rdfs:domain": "shex:Schema",
-        "rdfs:range": "shex:ShapeExpression"
+        "rdfs:range": "shex:ShapeDecl"
       },
       {
         "@id": "shex:start",
@@ -1034,6 +1145,18 @@
         },
         "rdfs:domain": "shex:Schema",
         "rdfs:range": "shex:SemAct"
+      },
+      {
+        "@id": "shex:status",
+        "@type": "rdf:Property",
+        "rdfs:label": {
+          "en": "status"
+        },
+        "rdfs:comment": {
+          "en": "The validation status of a node/shape association: \"conformant\" or \"nonconformant\". Defaults to \"conformant\"."
+        },
+        "rdfs:domain": "shex:ShapeMap",
+        "rdfs:range": "xsd:string"
       },
       {
         "@id": "shex:stem",
@@ -1125,6 +1248,26 @@
       }
     ],
     "rdfs_instances": [
+      {
+        "@id": "shex:FOCUS",
+        "@type": "rdfs:Resource",
+        "rdfs:label": {
+          "en": "FOCUS"
+        },
+        "rdfs:comment": {
+          "en": "In a triple pattern used as a node selector, indicates the position (subject or object) of the nodes to be selected. A triple pattern has exactly one focus selector."
+        }
+      },
+      {
+        "@id": "shex:_",
+        "@type": "rdfs:Resource",
+        "rdfs:label": {
+          "en": "wildcard"
+        },
+        "rdfs:comment": {
+          "en": "In a triple pattern used as a node selector, a wildcard indicating that the position (subject or object) may hold any value."
+        }
+      },
       {
         "@id": "shex:bnode",
         "@type": "NodeKind",

--- a/shex.ttl
+++ b/shex.ttl
@@ -9,9 +9,9 @@
 shex: a owl:Ontology;
   dc:title "Shape Expression Vocabulary"@en;
   dc:description """This document describes the RDFS vocabulary description used in the Shape Expression Language (ShEx) [[shex-semantics]] along with the default JSON-LD Context and shape expression to validate RDF versions of shapes."""@en;
-  dc:date "2017-07-07"^^xsd:date;
-  owl:versionInfo <https://github.com/shexSpec/shexspec.github.io/commit/e05f8e97471f5271f50612bed253102f770364b4>;
-  rdfs:seeAlso <http://shex.io/shex-semantics>;
+  dc:date "2026-08-06"^^xsd:date;
+  owl:versionInfo <https://github.com/shexSpec/shexTest/commit/e51237875c69bb1fbc86def8f3c895b213a6ff9c>;
+  rdfs:seeAlso <http://shex.io/shex-semantics>, <https://shexspec.github.io/shape-map/>;
   .
 
 
@@ -73,6 +73,10 @@ shex:OneOf a rdfs:Class;
   rdfs:comment """A TripleExpression composed of one or more sub-expressions, one of which must match."""@en;
   rdfs:subClassOf shex:TripleExpression;
   rdfs:isDefinedBy shex: .
+shex:QueryMap a rdfs:Class;
+  rdfs:label "Query Map"@en;
+  rdfs:comment """A map of node selectors to shape labels, used to select the nodes to be validated against particular shapes. Node selectors are RDF nodes or triple patterns."""@en;
+  rdfs:isDefinedBy shex: .
 shex:Schema a rdfs:Class;
   rdfs:label "Schema"@en;
   rdfs:comment """A Schema contains the set of shapes, used for matching a focus node."""@en;
@@ -91,6 +95,10 @@ shex:ShapeAnd a rdfs:Class;
   rdfs:comment """A ShapeExpression composed of one or more sub-expressions, all of which must match."""@en;
   rdfs:subClassOf shex:ShapeExpression;
   rdfs:isDefinedBy shex: .
+shex:ShapeDecl a rdfs:Class;
+  rdfs:label "Shape Declaration"@en;
+  rdfs:comment """Associates a shape expression with a label, and optionally declares it abstract. The shapes in a Schema are ShapeDecls."""@en;
+  rdfs:isDefinedBy shex: .
 shex:ShapeExpression a rdfs:Class;
   rdfs:label "Shape Expression"@en;
   rdfs:comment """The abstract class of Shape Expressions."""@en;
@@ -99,6 +107,11 @@ shex:ShapeExternal a rdfs:Class;
   rdfs:label "Shape External"@en;
   rdfs:comment """A reference to a shape defined in some external Schema."""@en;
   rdfs:subClassOf shex:ShapeExpression;
+  rdfs:isDefinedBy shex: .
+shex:ShapeMap a rdfs:Class;
+  rdfs:label "Shape Map"@en;
+  rdfs:comment """A QueryMap in which each node selector is an RDF node; associates RDF nodes with shapes, optionally recording the validation status of each association."""@en;
+  rdfs:subClassOf shex:QueryMap;
   rdfs:isDefinedBy shex: .
 shex:ShapeNot a rdfs:Class;
   rdfs:label "Shape Not"@en;
@@ -133,6 +146,12 @@ shex:Wildcard a rdfs:Class;
   rdfs:isDefinedBy shex: .
 
 # Property definitions
+shex:abstract a rdf:Property;
+  rdfs:label "abstract"@en;
+  rdfs:comment """Declares a ShapeDecl abstract, meaning that every reference to it must also identify at least one non-abstract shape."""@en;
+  rdfs:domain shex:ShapeDecl;
+  rdfs:range xsd:boolean;
+  rdfs:isDefinedBy shex: .
 shex:annotation a rdf:Property;
   rdfs:label "annotation"@en;
   rdfs:comment """Annotations on a TripleExpression."""@en;
@@ -175,15 +194,15 @@ shex:expressions a rdf:Property;
   rdfs:domain [ owl:unionOf (shex:EachOf shex:OneOf)];
   rdfs:range shex:TripleExpression;
   rdfs:isDefinedBy shex: .
-shex:extra a rdf:Property;
-  rdfs:label "extra"@en;
-  rdfs:comment """Properties which may have extra values beyond those matched through a constraint."""@en;
-  rdfs:domain shex:Shape;
-  rdfs:range rdfs:Resource;
-  rdfs:isDefinedBy shex: .
 shex:extends a rdf:Property;
   rdfs:label "extends"@en;
   rdfs:comment """Base shape expressions for this shape."""@en;
+  rdfs:domain shex:Shape;
+  rdfs:range shex:ShapeExpression;
+  rdfs:isDefinedBy shex: .
+shex:extra a rdf:Property;
+  rdfs:label "extra"@en;
+  rdfs:comment """Properties which may have extra values beyond those matched through a constraint."""@en;
   rdfs:domain shex:Shape;
   rdfs:range rdfs:Resource;
   rdfs:isDefinedBy shex: .
@@ -199,6 +218,12 @@ shex:fractiondigits a rdf:Property;
   rdfs:subPropertyOf shex:numericFacet;
   rdfs:domain shex:NodeConstraint;
   rdfs:range xsd:integer;
+  rdfs:isDefinedBy shex: .
+shex:imports a rdf:Property;
+  rdfs:label "imports"@en;
+  rdfs:comment """Schemas imported by this Schema; their shape and triple expression labels are also in scope here."""@en;
+  rdfs:domain shex:Schema;
+  rdfs:range rdfs:Resource;
   rdfs:isDefinedBy shex: .
 shex:inverse a rdf:Property;
   rdfs:label "inverse"@en;
@@ -279,6 +304,12 @@ shex:name a rdf:Property;
   rdfs:domain shex:SemAct;
   rdfs:range rdfs:Resource;
   rdfs:isDefinedBy shex: .
+shex:node a rdf:Property;
+  rdfs:label "node"@en;
+  rdfs:comment """An RDF node, or a triple pattern which is used to select RDF nodes to be validated."""@en;
+  rdfs:domain shex:QueryMap;
+  rdfs:range rdfs:Resource;
+  rdfs:isDefinedBy shex: .
 shex:nodeKind a rdf:Property;
   rdfs:label "node kind"@en;
   rdfs:comment """Restiction on the kind of node matched; restricted to the defined instances of NodeKind. One of shex:iri, shex:bnode, shex:literal, or shex:nonliteral."""@en;
@@ -315,10 +346,16 @@ shex:semActs a rdf:Property;
   rdfs:domain [ owl:unionOf (shex:EachOf shex:OneOf shex:TripleConstraint)];
   rdfs:range shex:SemAct;
   rdfs:isDefinedBy shex: .
+shex:shape a rdf:Property;
+  rdfs:label "shape"@en;
+  rdfs:comment """A ShEx shape expression label identifying the shape expression against which the selected nodes are validated, or the string "START" for the schema's start shape expression."""@en;
+  rdfs:domain shex:QueryMap;
+  rdfs:range shex:ShapeExpression;
+  rdfs:isDefinedBy shex: .
 shex:shapeExpr a rdf:Property;
   rdfs:label "shape expression"@en;
-  rdfs:comment """Shape Expression referenced by this shape."""@en;
-  rdfs:domain shex:ShapeNot;
+  rdfs:comment """Shape Expression referenced by this shape or shape declaration."""@en;
+  rdfs:domain [ owl:unionOf (shex:ShapeNot shex:ShapeDecl)];
   rdfs:range shex:ShapeExpression;
   rdfs:isDefinedBy shex: .
 shex:shapeExprs a rdf:Property;
@@ -330,9 +367,9 @@ shex:shapeExprs a rdf:Property;
   rdfs:isDefinedBy shex: .
 shex:shapes a rdf:Property;
   rdfs:label "shapes"@en;
-  rdfs:comment """Shapes in this Schema."""@en;
+  rdfs:comment """Shape declarations in this Schema."""@en;
   rdfs:domain shex:Schema;
-  rdfs:range shex:ShapeExpression;
+  rdfs:range shex:ShapeDecl;
   rdfs:isDefinedBy shex: .
 shex:start a rdf:Property;
   rdfs:label "start"@en;
@@ -345,6 +382,12 @@ shex:startActs a rdf:Property;
   rdfs:comment """Semantic Actions run on the Schema."""@en;
   rdfs:domain shex:Schema;
   rdfs:range shex:SemAct;
+  rdfs:isDefinedBy shex: .
+shex:status a rdf:Property;
+  rdfs:label "status"@en;
+  rdfs:comment """The validation status of a node/shape association: "conformant" or "nonconformant". Defaults to "conformant"."""@en;
+  rdfs:domain shex:ShapeMap;
+  rdfs:range xsd:string;
   rdfs:isDefinedBy shex: .
 shex:stem a rdf:Property;
   rdfs:label "stem"@en;
@@ -385,6 +428,14 @@ shex:xsFacet a rdf:Property;
 # Datatype definitions
 
 # Instance definitions
+shex:FOCUS a rdfs:Resource;
+  rdfs:label "FOCUS"@en;
+  rdfs:comment """In a triple pattern used as a node selector, indicates the position (subject or object) of the nodes to be selected. A triple pattern has exactly one focus selector."""@en;
+  rdfs:isDefinedBy shex: .
+shex:_ a rdfs:Resource;
+  rdfs:label "wildcard"@en;
+  rdfs:comment """In a triple pattern used as a node selector, a wildcard indicating that the position (subject or object) may hold any value."""@en;
+  rdfs:isDefinedBy shex: .
 shex:bnode a shex:NodeKind;
   rdfs:label "bnode"@en;
   rdfs:comment """Requires node to be a Blank Node"""@en;


### PR DESCRIPTION
Adds terms to the ShEx vocabulary (`http://www.w3.org/ns/shex#`) and regenerates the three published files from their source.

### Shape-map terms

Per [the ShapeMap spec](https://shexspec.github.io/shape-map/): classes `QueryMap` and `ShapeMap`, properties `node`, `shape` and `status`, and the `FOCUS` and `_` node-selector constants.

`ShapeMap` is `rdfs:subClassOf QueryMap`, following the spec's "a fixed ShapeMap is a query ShapeMap in which each node is an RDF node". `status` has range `xsd:string` so `"status": "conformant"` stays a plain string rather than requiring minted individuals; say the word if you'd rather have `shex:conformant`/`shex:nonconformant` with `@vocab` coercion, like `nodeKind`.

### ShapeDecl, abstract, imports

The RDF rendering of ShEx schemas has used these for years without them ever being published here. They come from the ShExJ grammar (`ShapeDecl { id, abstract:BOOL?, restricts:[…]?, shapeExpr }`, `Schema.imports:[IRIREF+]?`) and from shexTest's hand-maintained `doc/ShExR.shex`.

**These are the only changes to existing triples:**

| term | before | after | why |
| --- | --- | --- | --- |
| `shex:shapes` | range `ShapeExpression` | range `ShapeDecl` | ShExR: `sx:shapes @<#ShapeDeclList1Plus>` |
| `shex:shapeExpr` | domain `ShapeNot` | domain `ShapeNot ∣ ShapeDecl` | a ShapeDecl carries a `shapeExpr` too |

Everything else in the diff is new terms or regeneration.

`shex:start` has the same question — ShExR gives it `@<#shapeDeclOrExpr>`, i.e. `ShapeDecl OR shapeExpr` — but it is left alone here, since narrowing it is a further semantic change rather than one entailed by adding `ShapeDecl`.

`sx:negated`, which `ShExR.shex` also used, is deliberately **not** added. It was the ShEx 2.0 draft's `!` operator, removed from the language in November 2016 and replaced by `{0,0}` cardinality and `ShapeNot`; it was copied back into ShExR by mistake seven weeks later and never cleaned up. It has never been in this namespace, is not in the spec, and the ShExC parser has no `!` rule, so nothing can produce it. It is being removed from ShExR instead.

### These files are generated

`shex.ttl`, `shex.jsonld` and `shex.html` are built from a `vocab.csv`, by a script Gregg Kellogg (RIP) wrote for the purpose. That source had been sitting in the long-dormant `shexspec.github.io` repo; it now lives in [shexSpec/shexTest/vocab](https://github.com/shexSpec/shexTest/tree/main/vocab), ported to dependency-free Node and verified to reproduce the Ruby's output byte-for-byte. `owl:versionInfo` on each build records the `vocab.csv` commit it came from.

Please don't hand-edit these three files — regenerate instead, or the edits are lost on the next build. Regenerating here folds back the edits that had accumulated since 2017:

- `shex:extends` had **conflicting ranges**: `rdfs:Resource` in `shex.ttl` but `ShapeExpression` in `shex.jsonld`. Resolved to `ShapeExpression`.
- its `shex.html` row had lower-cased RDFa (`typeof="rdf:property"`, `resource="shex:shape"`, `property="rdfs:isdefinedby"`).
- `shex:shapes`' `@list` container was missing from the HTML term list.

### Checks

`shex.ttl` parses and `shex.jsonld` expands to the same graph (537 / 535 triples, the difference being the pre-existing prefixed-key quirk in the inner ontology context). The new terms were round-tripped through the published context on real ShExJ documents: `abstract` yields a typed `xsd:boolean`, `imports` an RDF list head matching ShExR's `IriList1Plus`, and `ShapeDecl`/`ShapeMap` the expected type arcs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)